### PR TITLE
Add database initialization, migrations, and connection handling

### DIFF
--- a/migrations/001_create_core_tables.sql
+++ b/migrations/001_create_core_tables.sql
@@ -1,0 +1,100 @@
+-- Projects
+CREATE TABLE projects (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  product_url TEXT,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+  settings TEXT DEFAULT '{}',
+  created_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Assessments
+CREATE TABLE assessments (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  test_date_start TEXT,
+  test_date_end TEXT,
+  status TEXT NOT NULL DEFAULT 'planning' CHECK (status IN ('planning', 'in_progress', 'completed')),
+  assigned_to TEXT,
+  created_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Issues
+CREATE TABLE issues (
+  id TEXT PRIMARY KEY,
+  assessment_id TEXT NOT NULL REFERENCES assessments(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  url TEXT,
+  severity TEXT NOT NULL DEFAULT 'medium' CHECK (severity IN ('critical', 'high', 'medium', 'low')),
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'resolved', 'wont_fix')),
+  wcag_codes TEXT DEFAULT '[]',
+  ai_suggested_codes TEXT DEFAULT '[]',
+  ai_confidence_score REAL,
+  device_type TEXT CHECK (device_type IN ('desktop', 'mobile', 'tablet') OR device_type IS NULL),
+  browser TEXT,
+  operating_system TEXT,
+  assistive_technology TEXT,
+  evidence_media TEXT DEFAULT '[]',
+  tags TEXT DEFAULT '[]',
+  created_by TEXT,
+  resolved_by TEXT,
+  resolved_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Reports
+CREATE TABLE reports (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  type TEXT NOT NULL DEFAULT 'detailed' CHECK (type IN ('executive', 'detailed', 'custom')),
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published')),
+  content TEXT DEFAULT '[]',
+  template_id TEXT,
+  ai_generated INTEGER NOT NULL DEFAULT 0,
+  created_by TEXT,
+  published_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- VPATs
+CREATE TABLE vpats (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published')),
+  version_number INTEGER NOT NULL DEFAULT 1,
+  wcag_scope TEXT DEFAULT '[]',
+  criteria_rows TEXT DEFAULT '[]',
+  ai_generated INTEGER NOT NULL DEFAULT 0,
+  created_by TEXT,
+  published_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Settings (key-value store)
+CREATE TABLE settings (
+  key TEXT PRIMARY KEY,
+  value TEXT DEFAULT '{}'
+);
+
+-- Users (for optional local auth)
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('admin', 'member')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "a11y-pm",
       "version": "0.1.0",
       "dependencies": {
+        "better-sqlite3": "^12.6.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.574.0",
@@ -24,6 +25,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -5121,6 +5123,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -6375,6 +6387,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -6382,6 +6414,20 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bidi-js": {
@@ -6392,6 +6438,26 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -6476,6 +6542,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-name": {
@@ -6610,6 +6700,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -7128,6 +7224,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -7141,6 +7252,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -7263,7 +7383,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -7380,6 +7499,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -8237,6 +8365,15 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -8442,6 +8579,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8563,6 +8706,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.3",
@@ -8800,6 +8949,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -9115,6 +9270,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9166,7 +9341,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -10769,6 +10949,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -10796,11 +10988,16 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -10908,6 +11105,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -11021,6 +11224,30 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -11280,7 +11507,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -11714,6 +11940,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11849,6 +12101,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -12001,6 +12263,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
@@ -12108,6 +12394,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/recast": {
@@ -12417,6 +12717,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -12871,6 +13191,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -13007,6 +13372,15 @@
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -13339,6 +13713,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -13546,6 +13948,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
@@ -13929,7 +14343,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
@@ -14406,7 +14819,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/wsl-utils": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "better-sqlite3": "^12.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.574.0",
@@ -43,6 +44,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/lib/db/__tests__/connection.test.ts
+++ b/src/lib/db/__tests__/connection.test.ts
@@ -43,4 +43,16 @@ describe('database connection', () => {
     closeDb();
     expect(db.open).toBe(false);
   });
+
+  it('creates the parent directory if it does not exist', () => {
+    const tmpDir = path.join(os.tmpdir(), `a11y-test-${Date.now()}`);
+    const dbPath = path.join(tmpDir, 'test.db');
+
+    const testDb = getDb(dbPath);
+    expect(testDb.open).toBe(true);
+    expect(fs.existsSync(tmpDir)).toBe(true);
+
+    closeDb();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
 });

--- a/src/lib/db/__tests__/connection.test.ts
+++ b/src/lib/db/__tests__/connection.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getDb, closeDb } from '../index';
+
+describe('database connection', () => {
+  afterEach(() => {
+    closeDb();
+  });
+
+  it('returns a database instance', () => {
+    const db = getDb(':memory:');
+    expect(db).toBeDefined();
+    expect(db.open).toBe(true);
+  });
+
+  it('returns the same instance on subsequent calls (singleton)', () => {
+    const db1 = getDb(':memory:');
+    const db2 = getDb(':memory:');
+    expect(db1).toBe(db2);
+  });
+
+  it('enables WAL mode for file-based databases', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'a11y-wal-'));
+    const dbPath = path.join(tmpDir, 'test.db');
+    const fileDb = getDb(dbPath);
+    const result = fileDb.pragma('journal_mode') as Array<{ journal_mode: string }>;
+    expect(result[0]?.journal_mode).toBe('wal');
+    closeDb();
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('enables foreign keys', () => {
+    const db = getDb(':memory:');
+    const result = db.pragma('foreign_keys') as Array<{ foreign_keys: number }>;
+    expect(result[0]?.foreign_keys).toBe(1);
+  });
+
+  it('closes the database connection', () => {
+    const db = getDb(':memory:');
+    closeDb();
+    expect(db.open).toBe(false);
+  });
+});

--- a/src/lib/db/__tests__/init.test.ts
+++ b/src/lib/db/__tests__/init.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach } from 'vitest';
+import { initDb, closeDb } from '../index';
+
+describe('initDb', () => {
+  afterEach(() => {
+    closeDb();
+  });
+
+  it('runs migrations and returns the database', () => {
+    const db = initDb(':memory:');
+    // Verify tables were created by the migration
+    const tables = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND substr(name,1,1) != '_' ORDER BY name"
+      )
+      .all() as Array<{ name: string }>;
+    const tableNames = tables.map((t) => t.name);
+    expect(tableNames).toContain('projects');
+    expect(tableNames).toContain('assessments');
+    expect(tableNames).toContain('issues');
+    expect(tableNames).toContain('reports');
+    expect(tableNames).toContain('vpats');
+    expect(tableNames).toContain('settings');
+    expect(tableNames).toContain('users');
+  });
+
+  it('is idempotent — calling initDb twice does not throw', () => {
+    initDb(':memory:');
+    expect(() => initDb(':memory:')).not.toThrow();
+  });
+});

--- a/src/lib/db/__tests__/load-migrations.test.ts
+++ b/src/lib/db/__tests__/load-migrations.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { loadMigrations } from '../load-migrations';
+
+describe('loadMigrations', () => {
+  it('loads .sql files from a directory in sorted order', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrations-'));
+    fs.writeFileSync(path.join(tmpDir, '002_second.sql'), 'CREATE TABLE second (id TEXT);');
+    fs.writeFileSync(path.join(tmpDir, '001_first.sql'), 'CREATE TABLE first (id TEXT);');
+    fs.writeFileSync(path.join(tmpDir, 'readme.md'), 'ignore me');
+
+    const migrations = loadMigrations(tmpDir);
+
+    expect(migrations).toHaveLength(2);
+    expect(migrations[0]?.name).toBe('001_first.sql');
+    expect(migrations[1]?.name).toBe('002_second.sql');
+    expect(migrations[0]?.sql).toContain('CREATE TABLE first');
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+
+  it('returns empty array for empty directory', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrations-'));
+
+    const migrations = loadMigrations(tmpDir);
+    expect(migrations).toEqual([]);
+
+    fs.rmSync(tmpDir, { recursive: true });
+  });
+});

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../migrate';
+
+describe('migration runner', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('creates the _migrations tracking table', () => {
+    runMigrations(db, []);
+    const table = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='_migrations'")
+      .get() as { name: string } | undefined;
+    expect(table?.name).toBe('_migrations');
+  });
+
+  it('runs migrations in order', () => {
+    const migrations = [
+      { name: '001_create_foo.sql', sql: 'CREATE TABLE foo (id TEXT PRIMARY KEY);' },
+      { name: '002_create_bar.sql', sql: 'CREATE TABLE bar (id TEXT PRIMARY KEY);' },
+    ];
+
+    runMigrations(db, migrations);
+
+    const tables = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('foo', 'bar') ORDER BY name"
+      )
+      .all() as Array<{ name: string }>;
+    expect(tables.map((t) => t.name)).toEqual(['bar', 'foo']);
+  });
+
+  it('skips already-applied migrations', () => {
+    const migrations = [
+      { name: '001_create_foo.sql', sql: 'CREATE TABLE foo (id TEXT PRIMARY KEY);' },
+    ];
+
+    runMigrations(db, migrations);
+    // Run again — should not throw "table already exists"
+    runMigrations(db, migrations);
+
+    const applied = db.prepare('SELECT name FROM _migrations ORDER BY name').all() as Array<{
+      name: string;
+    }>;
+    expect(applied).toHaveLength(1);
+    expect(applied[0]?.name).toBe('001_create_foo.sql');
+  });
+
+  it('records applied migrations with timestamp', () => {
+    const migrations = [
+      { name: '001_create_foo.sql', sql: 'CREATE TABLE foo (id TEXT PRIMARY KEY);' },
+    ];
+
+    runMigrations(db, migrations);
+
+    const record = db
+      .prepare('SELECT * FROM _migrations WHERE name = ?')
+      .get('001_create_foo.sql') as {
+      name: string;
+      applied_at: string;
+    };
+    expect(record.name).toBe('001_create_foo.sql');
+    expect(record.applied_at).toBeDefined();
+  });
+
+  it('only runs new migrations when some are already applied', () => {
+    const first = [{ name: '001_create_foo.sql', sql: 'CREATE TABLE foo (id TEXT PRIMARY KEY);' }];
+    runMigrations(db, first);
+
+    const all = [
+      ...first,
+      { name: '002_create_bar.sql', sql: 'CREATE TABLE bar (id TEXT PRIMARY KEY);' },
+    ];
+    runMigrations(db, all);
+
+    const applied = db.prepare('SELECT name FROM _migrations ORDER BY name').all() as Array<{
+      name: string;
+    }>;
+    expect(applied).toHaveLength(2);
+
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('foo', 'bar')")
+      .all();
+    expect(tables).toHaveLength(2);
+  });
+});

--- a/src/lib/db/__tests__/schema.test.ts
+++ b/src/lib/db/__tests__/schema.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../migrate';
+import { loadMigrations } from '../load-migrations';
+import path from 'path';
+
+interface TableInfo {
+  cid: number;
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+}
+
+interface ForeignKeyInfo {
+  table: string;
+  from: string;
+  to: string;
+}
+
+function getColumns(db: Database.Database, table: string): TableInfo[] {
+  return db.prepare(`PRAGMA table_info(${table})`).all() as TableInfo[];
+}
+
+function getColumnNames(db: Database.Database, table: string): string[] {
+  return getColumns(db, table).map((c) => c.name);
+}
+
+function getForeignKeys(db: Database.Database, table: string): ForeignKeyInfo[] {
+  return db.prepare(`PRAGMA foreign_key_list(${table})`).all() as ForeignKeyInfo[];
+}
+
+describe('core tables schema', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    const migrations = loadMigrations(path.resolve(__dirname, '../../../../migrations'));
+    runMigrations(db, migrations);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('projects', () => {
+    it('has the correct columns', () => {
+      const columns = getColumnNames(db, 'projects');
+      expect(columns).toEqual([
+        'id',
+        'name',
+        'description',
+        'product_url',
+        'status',
+        'settings',
+        'created_by',
+        'created_at',
+        'updated_at',
+      ]);
+    });
+
+    it('defaults status to active', () => {
+      db.prepare("INSERT INTO projects (id, name) VALUES ('p1', 'Test')").run();
+      const row = db.prepare('SELECT status FROM projects WHERE id = ?').get('p1') as {
+        status: string;
+      };
+      expect(row.status).toBe('active');
+    });
+  });
+
+  describe('assessments', () => {
+    it('has the correct columns', () => {
+      const columns = getColumnNames(db, 'assessments');
+      expect(columns).toEqual([
+        'id',
+        'project_id',
+        'name',
+        'description',
+        'test_date_start',
+        'test_date_end',
+        'status',
+        'assigned_to',
+        'created_by',
+        'created_at',
+        'updated_at',
+      ]);
+    });
+
+    it('has a foreign key to projects', () => {
+      const fks = getForeignKeys(db, 'assessments');
+      expect(fks.some((fk) => fk.table === 'projects' && fk.from === 'project_id')).toBe(true);
+    });
+
+    it('cascades delete when parent project is deleted', () => {
+      db.prepare("INSERT INTO projects (id, name) VALUES ('p1', 'Test')").run();
+      db.prepare(
+        "INSERT INTO assessments (id, project_id, name) VALUES ('a1', 'p1', 'Assessment 1')"
+      ).run();
+      db.prepare("DELETE FROM projects WHERE id = 'p1'").run();
+      const row = db.prepare("SELECT * FROM assessments WHERE id = 'a1'").get();
+      expect(row).toBeUndefined();
+    });
+  });
+
+  describe('issues', () => {
+    it('has the correct columns', () => {
+      const columns = getColumnNames(db, 'issues');
+      expect(columns).toEqual([
+        'id',
+        'assessment_id',
+        'title',
+        'description',
+        'url',
+        'severity',
+        'status',
+        'wcag_codes',
+        'ai_suggested_codes',
+        'ai_confidence_score',
+        'device_type',
+        'browser',
+        'operating_system',
+        'assistive_technology',
+        'evidence_media',
+        'tags',
+        'created_by',
+        'resolved_by',
+        'resolved_at',
+        'created_at',
+        'updated_at',
+      ]);
+    });
+
+    it('has a foreign key to assessments', () => {
+      const fks = getForeignKeys(db, 'issues');
+      expect(fks.some((fk) => fk.table === 'assessments' && fk.from === 'assessment_id')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('reports', () => {
+    it('has the correct columns', () => {
+      const columns = getColumnNames(db, 'reports');
+      expect(columns).toEqual([
+        'id',
+        'project_id',
+        'type',
+        'title',
+        'status',
+        'content',
+        'template_id',
+        'ai_generated',
+        'created_by',
+        'published_at',
+        'created_at',
+        'updated_at',
+      ]);
+    });
+
+    it('has a foreign key to projects', () => {
+      const fks = getForeignKeys(db, 'reports');
+      expect(fks.some((fk) => fk.table === 'projects' && fk.from === 'project_id')).toBe(true);
+    });
+  });
+
+  describe('vpats', () => {
+    it('has the correct columns', () => {
+      const columns = getColumnNames(db, 'vpats');
+      expect(columns).toEqual([
+        'id',
+        'project_id',
+        'title',
+        'status',
+        'version_number',
+        'wcag_scope',
+        'criteria_rows',
+        'ai_generated',
+        'created_by',
+        'published_at',
+        'created_at',
+        'updated_at',
+      ]);
+    });
+
+    it('has a foreign key to projects', () => {
+      const fks = getForeignKeys(db, 'vpats');
+      expect(fks.some((fk) => fk.table === 'projects' && fk.from === 'project_id')).toBe(true);
+    });
+  });
+
+  describe('settings', () => {
+    it('has key and value columns', () => {
+      const columns = getColumnNames(db, 'settings');
+      expect(columns).toEqual(['key', 'value']);
+    });
+
+    it('uses key as primary key', () => {
+      const cols = getColumns(db, 'settings');
+      const keyCol = cols.find((c) => c.name === 'key');
+      expect(keyCol?.pk).toBe(1);
+    });
+  });
+
+  describe('users', () => {
+    it('has the correct columns', () => {
+      const columns = getColumnNames(db, 'users');
+      expect(columns).toEqual([
+        'id',
+        'username',
+        'password_hash',
+        'role',
+        'created_at',
+        'updated_at',
+      ]);
+    });
+
+    it('defaults role to member', () => {
+      db.prepare(
+        "INSERT INTO users (id, username, password_hash) VALUES ('u1', 'alice', 'hash')"
+      ).run();
+      const row = db.prepare('SELECT role FROM users WHERE id = ?').get('u1') as { role: string };
+      expect(row.role).toBe('member');
+    });
+  });
+
+  describe('foreign key enforcement', () => {
+    it('rejects inserting an assessment with a nonexistent project_id', () => {
+      expect(() => {
+        db.prepare(
+          "INSERT INTO assessments (id, project_id, name) VALUES ('a1', 'nonexistent', 'Test')"
+        ).run();
+      }).toThrow();
+    });
+  });
+});

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import fs from 'fs';
 import path from 'path';
 import { runMigrations } from './migrate';
 import { loadMigrations } from './load-migrations';
@@ -12,6 +13,14 @@ export function getDb(dbPath?: string): Database.Database {
   if (db) return db;
 
   const resolvedPath = dbPath ?? process.env.DATABASE_PATH ?? DEFAULT_DB_PATH;
+
+  if (resolvedPath !== ':memory:') {
+    const dir = path.dirname(resolvedPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+
   db = new Database(resolvedPath);
 
   if (resolvedPath !== ':memory:') {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,19 +1,32 @@
 import Database from 'better-sqlite3';
+import path from 'path';
+import { runMigrations } from './migrate';
+import { loadMigrations } from './load-migrations';
 
 let db: Database.Database | null = null;
+
+const DEFAULT_DB_PATH = './data/a11y-logger.db';
+const MIGRATIONS_DIR = path.resolve(process.cwd(), 'migrations');
 
 export function getDb(dbPath?: string): Database.Database {
   if (db) return db;
 
-  const path = dbPath ?? process.env.DATABASE_PATH ?? './data/a11y-logger.db';
-  db = new Database(path);
+  const resolvedPath = dbPath ?? process.env.DATABASE_PATH ?? DEFAULT_DB_PATH;
+  db = new Database(resolvedPath);
 
-  if (path !== ':memory:') {
+  if (resolvedPath !== ':memory:') {
     db.pragma('journal_mode = WAL');
   }
   db.pragma('foreign_keys = ON');
 
   return db;
+}
+
+export function initDb(dbPath?: string): Database.Database {
+  const database = getDb(dbPath);
+  const migrations = loadMigrations(MIGRATIONS_DIR);
+  runMigrations(database, migrations);
+  return database;
 }
 
 export function closeDb(): void {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,0 +1,24 @@
+import Database from 'better-sqlite3';
+
+let db: Database.Database | null = null;
+
+export function getDb(dbPath?: string): Database.Database {
+  if (db) return db;
+
+  const path = dbPath ?? process.env.DATABASE_PATH ?? './data/a11y-logger.db';
+  db = new Database(path);
+
+  if (path !== ':memory:') {
+    db.pragma('journal_mode = WAL');
+  }
+  db.pragma('foreign_keys = ON');
+
+  return db;
+}
+
+export function closeDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}

--- a/src/lib/db/load-migrations.ts
+++ b/src/lib/db/load-migrations.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import type { Migration } from './migrate';
+
+export function loadMigrations(migrationsDir: string): Migration[] {
+  if (!fs.existsSync(migrationsDir)) return [];
+
+  return fs
+    .readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+    .map((name) => ({
+      name,
+      sql: fs.readFileSync(path.join(migrationsDir, name), 'utf-8'),
+    }));
+}

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -1,0 +1,30 @@
+import type Database from 'better-sqlite3';
+
+export interface Migration {
+  name: string;
+  sql: string;
+}
+
+export function runMigrations(db: Database.Database, migrations: Migration[]): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS _migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  const applied = new Set(
+    (db.prepare('SELECT name FROM _migrations').all() as Array<{ name: string }>).map((r) => r.name)
+  );
+
+  const pending = migrations
+    .filter((m) => !applied.has(m.name))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const migration of pending) {
+    db.transaction(() => {
+      db.exec(migration.sql);
+      db.prepare('INSERT INTO _migrations (name) VALUES (?)').run(migration.name);
+    })();
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,8 @@ export default defineConfig({
         '__tests__/**',
         'e2e/**',
         'src/components/ui/**',
+        'migrations/**',
+        'src/lib/db/__tests__/**',
       ],
     },
   },


### PR DESCRIPTION
### Summary

This pull request introduces a new database initialization system with the following changes:
- Added `getDb()` for establishing a SQLite database connection. It supports WAL mode for file-based databases and an in-memory option for testing.
- Implemented `initDb()`, which runs all pending migrations on startup.
- Created a migration system, including:
  - File-based migration loader that processes `.sql` scripts in a specified directory.
  - Automatic tracking of applied migrations in a `_migrations` table.
  - Idempotent migration runner to ensure migrations are applied in order and within transactions.
- Added an initial migration script to create core tables (`projects`, `assessments`, `issues`, `reports`, etc.) with foreign key constraints and enum checks.
- Enhanced test coverage configuration by excluding irrelevant directories (`migrations/`).

### Checklist

- [x] Tests added or updated
- [x] Documentation updated (if needed)