### PR TITLE
Add report management APIs with validation and fixes

### DIFF
--- a/src/app/api/reports/[id]/__tests__/route.test.ts
+++ b/src/app/api/reports/[id]/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { createReport, publishReport } from '@/lib/db/reports';
+import { GET, PUT, DELETE } from '../route';
+
+let projectId: string;
+let reportId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM reports').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = createProject({ name: 'Test Project' });
+  projectId = project.id;
+  const report = createReport({ title: 'Test Report', project_id: projectId });
+  reportId = report.id;
+});
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/reports/[id]', () => {
+  it('returns the report', async () => {
+    const response = await GET(
+      new Request(`http://localhost/api/reports/${reportId}`),
+      makeContext(reportId)
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe(reportId);
+    expect(body.data.title).toBe('Test Report');
+  });
+
+  it('returns 404 when report does not exist', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/reports/no-report'),
+      makeContext('no-report')
+    );
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+});
+
+describe('PUT /api/reports/[id]', () => {
+  it('updates the report and returns it', async () => {
+    const request = new Request(`http://localhost/api/reports/${reportId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Updated Title', type: 'executive' }),
+    });
+    const response = await PUT(request, makeContext(reportId));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.title).toBe('Updated Title');
+    expect(body.data.type).toBe('executive');
+  });
+
+  it('returns 400 for invalid update data', async () => {
+    const request = new Request(`http://localhost/api/reports/${reportId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '' }),
+    });
+    const response = await PUT(request, makeContext(reportId));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 when report does not exist', async () => {
+    const request = new Request('http://localhost/api/reports/no-report', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'X' }),
+    });
+    const response = await PUT(request, makeContext('no-report'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 409 when report is published (immutable)', async () => {
+    publishReport(reportId);
+    const request = new Request(`http://localhost/api/reports/${reportId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Attempt Edit' }),
+    });
+    const response = await PUT(request, makeContext(reportId));
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.code).toBe('CONFLICT');
+  });
+});
+
+describe('DELETE /api/reports/[id]', () => {
+  it('deletes the report and returns success', async () => {
+    const response = await DELETE(
+      new Request(`http://localhost/api/reports/${reportId}`),
+      makeContext(reportId)
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, data: null });
+  });
+
+  it('returns 404 when report does not exist', async () => {
+    const response = await DELETE(
+      new Request('http://localhost/api/reports/no-report'),
+      makeContext('no-report')
+    );
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+});

--- a/src/app/api/reports/[id]/publish/__tests__/route.test.ts
+++ b/src/app/api/reports/[id]/publish/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { createReport } from '@/lib/db/reports';
+import { POST } from '../route';
+
+let projectId: string;
+let reportId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM reports').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = createProject({ name: 'Test Project' });
+  projectId = project.id;
+  const report = createReport({ title: 'Draft Report', project_id: projectId });
+  reportId = report.id;
+});
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('POST /api/reports/[id]/publish', () => {
+  it('publishes a draft report and returns it', async () => {
+    const response = await POST(
+      new Request(`http://localhost/api/reports/${reportId}/publish`, { method: 'POST' }),
+      makeContext(reportId)
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe('published');
+    expect(body.data.published_at).not.toBeNull();
+  });
+
+  it('returns 404 when report does not exist', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/reports/no-report/publish', { method: 'POST' }),
+      makeContext('no-report')
+    );
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  it('is idempotent — publishing an already-published report returns 200 and preserves published_at', async () => {
+    // First publish
+    const first = await POST(
+      new Request(`http://localhost/api/reports/${reportId}/publish`, { method: 'POST' }),
+      makeContext(reportId)
+    );
+    const firstBody = await first.json();
+    const firstPublishedAt = firstBody.data.published_at;
+
+    // Second publish
+    const second = await POST(
+      new Request(`http://localhost/api/reports/${reportId}/publish`, { method: 'POST' }),
+      makeContext(reportId)
+    );
+    expect(second.status).toBe(200);
+    const secondBody = await second.json();
+    expect(secondBody.data.status).toBe('published');
+    expect(secondBody.data.published_at).toBe(firstPublishedAt);
+  });
+});

--- a/src/app/api/reports/[id]/publish/route.ts
+++ b/src/app/api/reports/[id]/publish/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { getReport, publishReport } from '@/lib/db/reports';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+
+  try {
+    const existing = getReport(id);
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    const published = publishReport(id);
+    return NextResponse.json({ success: true, data: published });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to publish report', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/reports/[id]/publish/route.ts
+++ b/src/app/api/reports/[id]/publish/route.ts
@@ -16,6 +16,12 @@ export async function POST(_request: Request, { params }: RouteContext) {
     }
 
     const published = publishReport(id);
+    if (!published) {
+      return NextResponse.json(
+        { success: false, error: 'Failed to publish report', code: 'INTERNAL_ERROR' },
+        { status: 500 }
+      );
+    }
     return NextResponse.json({ success: true, data: published });
   } catch {
     return NextResponse.json(

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server';
+import { getReport, updateReport, deleteReport } from '@/lib/db/reports';
+import { UpdateReportSchema } from '@/lib/validators/reports';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+
+  try {
+    const report = getReport(id);
+    if (!report) {
+      return NextResponse.json(
+        { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+    return NextResponse.json({ success: true, data: report });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch report', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: Request, { params }: RouteContext) {
+  const { id } = await params;
+
+  try {
+    const existing = getReport(id);
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    if (existing.status === 'published') {
+      return NextResponse.json(
+        { success: false, error: 'Cannot edit a published report', code: 'CONFLICT' },
+        { status: 409 }
+      );
+    }
+
+    const body = await request.json();
+    const result = UpdateReportSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error.issues.map((i) => i.message).join('; '),
+          code: 'VALIDATION_ERROR',
+        },
+        { status: 400 }
+      );
+    }
+
+    const updated = updateReport(id, result.data);
+    if (!updated) {
+      return NextResponse.json(
+        { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: updated });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to update report', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+
+  try {
+    const existing = getReport(id);
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    deleteReport(id);
+    return NextResponse.json({ success: true, data: null });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to delete report', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/reports/__tests__/route.test.ts
+++ b/src/app/api/reports/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { createReport } from '@/lib/db/reports';
+import { GET, POST } from '../route';
+
+let projectId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM reports').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = createProject({ name: 'Test Project' });
+  projectId = project.id;
+});
+
+describe('GET /api/reports', () => {
+  it('returns empty array when no reports exist', async () => {
+    const response = await GET(new Request('http://localhost/api/reports'));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, data: [] });
+  });
+
+  it('returns all reports when no projectId filter', async () => {
+    const other = createProject({ name: 'Other' });
+    createReport({ title: 'Report A', project_id: projectId });
+    createReport({ title: 'Report B', project_id: other.id });
+    const response = await GET(new Request('http://localhost/api/reports'));
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(2);
+  });
+
+  it('filters by projectId query param', async () => {
+    const other = createProject({ name: 'Other' });
+    createReport({ title: 'Mine', project_id: projectId });
+    createReport({ title: 'Theirs', project_id: other.id });
+    const response = await GET(new Request(`http://localhost/api/reports?projectId=${projectId}`));
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].title).toBe('Mine');
+  });
+});
+
+describe('POST /api/reports', () => {
+  it('creates a report and returns 201', async () => {
+    const request = new Request('http://localhost/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'New Report', project_id: projectId }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.title).toBe('New Report');
+    expect(body.data.id).toBeDefined();
+    expect(body.data.project_id).toBe(projectId);
+    expect(body.data.status).toBe('draft');
+  });
+
+  it('creates a report with content sections', async () => {
+    const request = new Request('http://localhost/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Report with Sections',
+        project_id: projectId,
+        content: [{ title: 'Overview', body: '## Summary' }],
+      }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.data.content).toBe(JSON.stringify([{ title: 'Overview', body: '## Summary' }]));
+  });
+
+  it('returns 400 for missing title', async () => {
+    const request = new Request('http://localhost/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project_id: projectId }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for missing project_id', async () => {
+    const request = new Request('http://localhost/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Orphan' }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 when project does not exist', async () => {
+    const request = new Request('http://localhost/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Report', project_id: 'nonexistent' }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+});

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { getProject } from '@/lib/db/projects';
+import { getReports, createReport } from '@/lib/db/reports';
+import { CreateReportSchema } from '@/lib/validators/reports';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('projectId') ?? undefined;
+    const reports = getReports(projectId);
+    return NextResponse.json({ success: true, data: reports });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch reports', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const result = CreateReportSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error.issues.map((i) => i.message).join('; '),
+          code: 'VALIDATION_ERROR',
+        },
+        { status: 400 }
+      );
+    }
+
+    const project = getProject(result.data.project_id);
+    if (!project) {
+      return NextResponse.json(
+        { success: false, error: 'Project not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    const report = createReport(result.data);
+    return NextResponse.json({ success: true, data: report }, { status: 201 });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to create report', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/db/__tests__/reports.test.ts
+++ b/src/lib/db/__tests__/reports.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '../index';
+import { createProject } from '../projects';
+import {
+  createReport,
+  getReport,
+  getReports,
+  updateReport,
+  deleteReport,
+  publishReport,
+} from '../reports';
+
+let projectId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  // Clear child tables before parent due to FK constraints
+  getDb().prepare('DELETE FROM reports').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = createProject({ name: 'Test Project' });
+  projectId = project.id;
+});
+
+describe('createReport', () => {
+  it('inserts a report and returns it', () => {
+    const report = createReport({ title: 'Q1 Report', project_id: projectId });
+    expect(report.id).toBeDefined();
+    expect(report.title).toBe('Q1 Report');
+    expect(report.project_id).toBe(projectId);
+    expect(report.status).toBe('draft');
+    expect(report.type).toBe('detailed');
+    expect(report.content).toBe('[]');
+    expect(report.created_at).toBeDefined();
+    expect(report.updated_at).toBeDefined();
+  });
+
+  it('generates a unique id for each report', () => {
+    const r1 = createReport({ title: 'Report A', project_id: projectId });
+    const r2 = createReport({ title: 'Report B', project_id: projectId });
+    expect(r1.id).not.toBe(r2.id);
+  });
+
+  it('stores optional type field', () => {
+    const report = createReport({
+      title: 'Executive Summary',
+      project_id: projectId,
+      type: 'executive',
+    });
+    expect(report.type).toBe('executive');
+  });
+
+  it('serialises content array to JSON string', () => {
+    const report = createReport({
+      title: 'With Content',
+      project_id: projectId,
+      content: [{ title: 'Overview', body: '## Summary' }],
+    });
+    expect(report.content).toBe(JSON.stringify([{ title: 'Overview', body: '## Summary' }]));
+  });
+
+  it('stores null for omitted optional fields', () => {
+    const report = createReport({ title: 'Minimal', project_id: projectId });
+    expect(report.template_id).toBeNull();
+    expect(report.published_at).toBeNull();
+    expect(report.created_by).toBeNull();
+  });
+});
+
+describe('getReport', () => {
+  it('returns the report by id', () => {
+    const created = createReport({ title: 'Find Me', project_id: projectId });
+    const found = getReport(created.id);
+    expect(found).not.toBeNull();
+    expect(found?.title).toBe('Find Me');
+  });
+
+  it('returns null for nonexistent id', () => {
+    expect(getReport('nonexistent')).toBeNull();
+  });
+});
+
+describe('getReports', () => {
+  it('returns empty array when no reports exist', () => {
+    expect(getReports()).toEqual([]);
+  });
+
+  it('returns all reports when no projectId filter', () => {
+    const otherProject = createProject({ name: 'Other' });
+    createReport({ title: 'Mine', project_id: projectId });
+    createReport({ title: 'Theirs', project_id: otherProject.id });
+    expect(getReports()).toHaveLength(2);
+  });
+
+  it('filters by projectId when provided', () => {
+    const otherProject = createProject({ name: 'Other' });
+    createReport({ title: 'Mine', project_id: projectId });
+    createReport({ title: 'Theirs', project_id: otherProject.id });
+    const results = getReports(projectId);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.title).toBe('Mine');
+  });
+
+  it('returns reports ordered by created_at descending', () => {
+    createReport({ title: 'First', project_id: projectId });
+    createReport({ title: 'Second', project_id: projectId });
+    const results = getReports(projectId);
+    expect(results).toHaveLength(2);
+  });
+});
+
+describe('updateReport', () => {
+  it('updates provided fields and returns the updated report', () => {
+    const created = createReport({ title: 'Original', project_id: projectId });
+    const updated = updateReport(created.id, { title: 'Updated' });
+    expect(updated).not.toBeNull();
+    expect(updated!.title).toBe('Updated');
+  });
+
+  it('does not change fields not included in the update', () => {
+    const created = createReport({ title: 'Keep', project_id: projectId, type: 'executive' });
+    const updated = updateReport(created.id, { title: 'New Title' });
+    expect(updated!.type).toBe('executive');
+  });
+
+  it('serialises content array to JSON string on update', () => {
+    const created = createReport({ title: 'Content Report', project_id: projectId });
+    const updated = updateReport(created.id, {
+      content: [{ title: 'Section', body: 'Body text' }],
+    });
+    expect(updated!.content).toBe(JSON.stringify([{ title: 'Section', body: 'Body text' }]));
+  });
+
+  it('sets updated_at on update', () => {
+    const created = createReport({ title: 'Time Test', project_id: projectId });
+    const updated = updateReport(created.id, { title: 'Changed' });
+    expect(updated!.updated_at).toBeDefined();
+  });
+
+  it('returns null for nonexistent id', () => {
+    expect(updateReport('nope', { title: 'X' })).toBeNull();
+  });
+
+  it('returns existing report when no fields change', () => {
+    const created = createReport({ title: 'Unchanged', project_id: projectId });
+    const result = updateReport(created.id, {});
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Unchanged');
+  });
+
+  it('returns null when trying to update a published report', () => {
+    const created = createReport({ title: 'Published', project_id: projectId });
+    publishReport(created.id);
+    const result = updateReport(created.id, { title: 'Attempted Edit' });
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteReport', () => {
+  it('removes the report', () => {
+    const created = createReport({ title: 'Delete Me', project_id: projectId });
+    deleteReport(created.id);
+    expect(getReport(created.id)).toBeNull();
+  });
+
+  it('returns true when report existed', () => {
+    const created = createReport({ title: 'Exists', project_id: projectId });
+    expect(deleteReport(created.id)).toBe(true);
+  });
+
+  it('returns false when report did not exist', () => {
+    expect(deleteReport('ghost-id')).toBe(false);
+  });
+});
+
+describe('publishReport', () => {
+  it('sets status to published and records published_at', () => {
+    const created = createReport({ title: 'To Publish', project_id: projectId });
+    const published = publishReport(created.id);
+    expect(published).not.toBeNull();
+    expect(published!.status).toBe('published');
+    expect(published!.published_at).toBeDefined();
+    expect(published!.published_at).not.toBeNull();
+  });
+
+  it('returns null for nonexistent id', () => {
+    expect(publishReport('ghost-id')).toBeNull();
+  });
+
+  it('is idempotent — publishing an already-published report succeeds', () => {
+    const created = createReport({ title: 'Already Published', project_id: projectId });
+    publishReport(created.id);
+    const again = publishReport(created.id);
+    expect(again?.status).toBe('published');
+  });
+});

--- a/src/lib/db/__tests__/reports.test.ts
+++ b/src/lib/db/__tests__/reports.test.ts
@@ -194,10 +194,11 @@ describe('publishReport', () => {
     expect(publishReport('ghost-id')).toBeNull();
   });
 
-  it('is idempotent — publishing an already-published report succeeds', () => {
+  it('is idempotent — publishing an already-published report preserves original published_at', () => {
     const created = createReport({ title: 'Already Published', project_id: projectId });
-    publishReport(created.id);
-    const again = publishReport(created.id);
-    expect(again?.status).toBe('published');
+    const first = publishReport(created.id);
+    const second = publishReport(created.id);
+    expect(second?.status).toBe('published');
+    expect(second?.published_at).toBe(first?.published_at);
   });
 });

--- a/src/lib/db/reports.ts
+++ b/src/lib/db/reports.ts
@@ -1,0 +1,111 @@
+import { getDb } from './index';
+import type { CreateReportInput, UpdateReportInput } from '../validators/reports';
+
+export interface Report {
+  id: string;
+  project_id: string;
+  type: 'executive' | 'detailed' | 'custom';
+  title: string;
+  status: 'draft' | 'published';
+  content: string; // JSON string: [{title, body}]
+  template_id: string | null;
+  ai_generated: number; // 0 | 1
+  created_by: string | null;
+  published_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function getReport(id: string): Report | null {
+  return (
+    (getDb().prepare('SELECT * FROM reports WHERE id = ?').get(id) as Report | undefined) ?? null
+  );
+}
+
+export function getReports(projectId?: string): Report[] {
+  if (projectId) {
+    return getDb()
+      .prepare('SELECT * FROM reports WHERE project_id = ? ORDER BY created_at DESC')
+      .all(projectId) as Report[];
+  }
+  return getDb().prepare('SELECT * FROM reports ORDER BY created_at DESC').all() as Report[];
+}
+
+export function createReport(input: CreateReportInput): Report {
+  const id = crypto.randomUUID();
+  const db = getDb();
+  db.prepare(
+    `INSERT INTO reports (id, project_id, title, type, content, template_id, ai_generated)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
+  ).run(
+    id,
+    input.project_id,
+    input.title,
+    input.type ?? 'detailed',
+    input.content ? JSON.stringify(input.content) : '[]',
+    input.template_id ?? null,
+    input.ai_generated ? 1 : 0
+  );
+  return getReport(id)!;
+}
+
+export function updateReport(id: string, input: UpdateReportInput): Report | null {
+  const existing = getReport(id);
+  if (!existing) return null;
+
+  // Published reports are immutable
+  if (existing.status === 'published') return null;
+
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  if (input.title !== undefined) {
+    fields.push('title = ?');
+    values.push(input.title);
+  }
+  if (input.type !== undefined) {
+    fields.push('type = ?');
+    values.push(input.type);
+  }
+  if (input.content !== undefined) {
+    fields.push('content = ?');
+    values.push(JSON.stringify(input.content));
+  }
+  if (input.template_id !== undefined) {
+    fields.push('template_id = ?');
+    values.push(input.template_id);
+  }
+  if (input.ai_generated !== undefined) {
+    fields.push('ai_generated = ?');
+    values.push(input.ai_generated ? 1 : 0);
+  }
+
+  if (fields.length === 0) return existing;
+
+  fields.push("updated_at = datetime('now')");
+  values.push(id);
+
+  getDb()
+    .prepare(`UPDATE reports SET ${fields.join(', ')} WHERE id = ?`)
+    .run(...values);
+
+  return getReport(id);
+}
+
+export function deleteReport(id: string): boolean {
+  const result = getDb().prepare('DELETE FROM reports WHERE id = ?').run(id);
+  return result.changes > 0;
+}
+
+export function publishReport(id: string): Report | null {
+  const existing = getReport(id);
+  if (!existing) return null;
+
+  getDb()
+    .prepare(
+      `UPDATE reports SET status = 'published', published_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`
+    )
+    .run(id);
+
+  return getReport(id);
+}

--- a/src/lib/db/reports.ts
+++ b/src/lib/db/reports.ts
@@ -101,6 +101,9 @@ export function publishReport(id: string): Report | null {
   const existing = getReport(id);
   if (!existing) return null;
 
+  // Already published — return as-is to preserve original published_at
+  if (existing.status === 'published') return existing;
+
   getDb()
     .prepare(
       `UPDATE reports SET status = 'published', published_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`

--- a/src/lib/validators/__tests__/reports.test.ts
+++ b/src/lib/validators/__tests__/reports.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { CreateReportSchema, UpdateReportSchema } from '../reports';
+
+describe('CreateReportSchema', () => {
+  it('accepts a valid minimal input', () => {
+    const result = CreateReportSchema.safeParse({
+      title: 'Quarterly Report',
+      project_id: 'proj-123',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all optional fields', () => {
+    const result = CreateReportSchema.safeParse({
+      title: 'Full Report',
+      project_id: 'proj-123',
+      type: 'executive',
+      content: [{ title: 'Overview', body: '## Summary\n\nAll good.' }],
+      template_id: 'tmpl-abc',
+      ai_generated: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing title', () => {
+    const result = CreateReportSchema.safeParse({ project_id: 'proj-123' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty title', () => {
+    const result = CreateReportSchema.safeParse({ title: '', project_id: 'proj-123' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects title over 200 chars', () => {
+    const result = CreateReportSchema.safeParse({
+      title: 'A'.repeat(201),
+      project_id: 'proj-123',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing project_id', () => {
+    const result = CreateReportSchema.safeParse({ title: 'Report' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid type', () => {
+    const result = CreateReportSchema.safeParse({
+      title: 'Report',
+      project_id: 'proj-123',
+      type: 'invalid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects content section missing body', () => {
+    const result = CreateReportSchema.safeParse({
+      title: 'Report',
+      project_id: 'proj-123',
+      content: [{ title: 'Overview' }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('UpdateReportSchema', () => {
+  it('accepts empty object (no-op update)', () => {
+    const result = UpdateReportSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts partial update', () => {
+    const result = UpdateReportSchema.safeParse({ title: 'New Title' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty title in partial update', () => {
+    const result = UpdateReportSchema.safeParse({ title: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('does not accept project_id (not updatable)', () => {
+    // project_id should not be present in UpdateReportSchema
+    const schema = UpdateReportSchema;
+    expect((schema as { shape?: unknown }).shape).not.toHaveProperty('project_id');
+  });
+});

--- a/src/lib/validators/__tests__/reports.test.ts
+++ b/src/lib/validators/__tests__/reports.test.ts
@@ -80,9 +80,12 @@ describe('UpdateReportSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('does not accept project_id (not updatable)', () => {
-    // project_id should not be present in UpdateReportSchema
-    const schema = UpdateReportSchema;
-    expect((schema as { shape?: unknown }).shape).not.toHaveProperty('project_id');
+  it('does not include project_id in parsed output (not updatable)', () => {
+    const result = UpdateReportSchema.safeParse({
+      title: 'Updated Title',
+      project_id: 'proj-should-be-ignored',
+    });
+    expect(result.success).toBe(true);
+    expect((result.data as Record<string, unknown>).project_id).toBeUndefined();
   });
 });

--- a/src/lib/validators/reports.ts
+++ b/src/lib/validators/reports.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+const ContentSectionSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+});
+
+const ReportBaseSchema = z.object({
+  title: z.string().min(1).max(200),
+  type: z.enum(['executive', 'detailed', 'custom']).optional(),
+  content: z.array(ContentSectionSchema).optional(),
+  template_id: z.string().optional(),
+  ai_generated: z.boolean().optional(),
+});
+
+export const CreateReportSchema = ReportBaseSchema.extend({
+  project_id: z.string().min(1),
+});
+
+export const UpdateReportSchema = ReportBaseSchema.partial();
+
+export type ContentSection = z.infer<typeof ContentSectionSchema>;
+export type CreateReportInput = z.infer<typeof CreateReportSchema>;
+export type UpdateReportInput = z.infer<typeof UpdateReportSchema>;


### PR DESCRIPTION
### Summary

This pull request introduces a comprehensive set of API routes for managing reports, as well as validation and bug fixes:

- **Features:**
  - Added API endpoints for report management:
    - `GET`, `POST` for handling the reports collection.
    - `GET`, `PUT`, `DELETE` for managing individual reports.
    - API for publishing reports.
  - Integrated a Zod-based validator for validating report data.
  - Introduced a data access layer for reports to centralize database interaction.

- **Fixes:**
  - Addressed a potential issue with null returns from the `publishReport` function in the route handler.
  - Preserved the original `published_at` timestamp during report re-publishing.

- **Tests:**
  - Improvements made to the `project_id` exclusion test in the validator.