### PR TITLE
Add settings and users APIs with authentication and encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "a11y-pm",
       "version": "0.1.0",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.6.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -26,6 +27,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -5124,6 +5126,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -6414,6 +6423,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -45,6 +46,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/bcryptjs": "^2.4.6",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/app/api/settings/[key]/__tests__/route.test.ts
+++ b/src/app/api/settings/[key]/__tests__/route.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { setSetting } from '@/lib/db/settings';
+import { GET, PUT } from '../route';
+
+vi.stubEnv('ENCRYPTION_SECRET', 'a'.repeat(64));
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM settings').run();
+});
+
+type RouteContext = { params: Promise<{ key: string }> };
+
+function makeContext(key: string): RouteContext {
+  return { params: Promise.resolve({ key }) };
+}
+
+describe('GET /api/settings/[key]', () => {
+  it('returns a single setting value', async () => {
+    setSetting('ai_provider', 'openai');
+    const response = await GET(new Request('http://localhost'), makeContext('ai_provider'));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, data: { key: 'ai_provider', value: 'openai' } });
+  });
+
+  it('returns 404 for a non-existent key', async () => {
+    const response = await GET(new Request('http://localhost'), makeContext('nonexistent'));
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  it('redacts sensitive keys', async () => {
+    setSetting('ai_api_key', 'sk-real-key');
+    const response = await GET(new Request('http://localhost'), makeContext('ai_api_key'));
+    const body = await response.json();
+    expect(body.data.value).toBe('[REDACTED]');
+  });
+});
+
+describe('PUT /api/settings/[key]', () => {
+  it('creates or updates a setting and returns it', async () => {
+    const request = new Request('http://localhost', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: 'anthropic' }),
+    });
+    const response = await PUT(request, makeContext('ai_provider'));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toEqual({ key: 'ai_provider', value: 'anthropic' });
+  });
+
+  it('returns 400 when body is missing value field', async () => {
+    const request = new Request('http://localhost', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const response = await PUT(request, makeContext('ai_provider'));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/src/app/api/settings/[key]/route.ts
+++ b/src/app/api/settings/[key]/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { getSetting, setSetting } from '@/lib/db/settings';
+import { SENSITIVE_KEYS } from '@/lib/crypto';
+import { UpdateSettingSchema } from '@/lib/validators/settings';
+
+type RouteContext = { params: Promise<{ key: string }> };
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  try {
+    const { key } = await params;
+    const value = getSetting(key);
+
+    if (value === null) {
+      return NextResponse.json(
+        { success: false, error: 'Setting not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    const redacted = (SENSITIVE_KEYS as readonly string[]).includes(key) ? '[REDACTED]' : value;
+    return NextResponse.json({ success: true, data: { key, value: redacted } });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch setting', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: Request, { params }: RouteContext) {
+  try {
+    const { key } = await params;
+    const body = await request.json();
+    const result = UpdateSettingSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error.issues.map((i) => i.message).join('; '),
+          code: 'VALIDATION_ERROR',
+        },
+        { status: 400 }
+      );
+    }
+
+    setSetting(key, result.data.value);
+
+    const stored = getSetting(key);
+    const redacted = (SENSITIVE_KEYS as readonly string[]).includes(key) ? '[REDACTED]' : stored;
+    return NextResponse.json({ success: true, data: { key, value: redacted } });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to update setting', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/settings/[key]/route.ts
+++ b/src/app/api/settings/[key]/route.ts
@@ -6,8 +6,8 @@ import { UpdateSettingSchema } from '@/lib/validators/settings';
 type RouteContext = { params: Promise<{ key: string }> };
 
 export async function GET(_request: Request, { params }: RouteContext) {
+  const { key } = await params;
   try {
-    const { key } = await params;
     const value = getSetting(key);
 
     if (value === null) {
@@ -28,8 +28,8 @@ export async function GET(_request: Request, { params }: RouteContext) {
 }
 
 export async function PUT(request: Request, { params }: RouteContext) {
+  const { key } = await params;
   try {
-    const { key } = await params;
     const body = await request.json();
     const result = UpdateSettingSchema.safeParse(body);
 

--- a/src/app/api/settings/__tests__/route.test.ts
+++ b/src/app/api/settings/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { setSetting } from '@/lib/db/settings';
+import { GET, PUT } from '../route';
+
+vi.stubEnv('ENCRYPTION_SECRET', 'a'.repeat(64));
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM settings').run();
+});
+
+describe('GET /api/settings', () => {
+  it('returns success with empty object when no settings exist', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, data: {} });
+  });
+
+  it('returns all settings with sensitive keys redacted', async () => {
+    setSetting('ai_provider', 'openai');
+    setSetting('ai_api_key', 'sk-secret');
+    const response = await GET();
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.ai_provider).toBe('openai');
+    expect(body.data.ai_api_key).toBe('[REDACTED]');
+  });
+});
+
+describe('PUT /api/settings', () => {
+  it('updates multiple settings and returns redacted values', async () => {
+    const request = new Request('http://localhost/api/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ai_provider: 'anthropic', auth_enabled: true }),
+    });
+    const response = await PUT(request);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.ai_provider).toBe('anthropic');
+    expect(body.data.auth_enabled).toBe(true);
+  });
+
+  it('returns 400 for invalid input (not an object)', async () => {
+    const request = new Request('http://localhost/api/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify('not-an-object'),
+    });
+    const response = await PUT(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getSettings, setSetting } from '@/lib/db/settings';
+import { BatchUpdateSettingsSchema } from '@/lib/validators/settings';
+
+export async function GET() {
+  try {
+    const settings = getSettings();
+    return NextResponse.json({ success: true, data: settings });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch settings', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const body = await request.json();
+    const result = BatchUpdateSettingsSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error.issues.map((i) => i.message).join('; '),
+          code: 'VALIDATION_ERROR',
+        },
+        { status: 400 }
+      );
+    }
+
+    for (const [key, value] of Object.entries(result.data)) {
+      setSetting(key, value);
+    }
+
+    return NextResponse.json({ success: true, data: getSettings() });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to update settings', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/[id]/__tests__/route.test.ts
+++ b/src/app/api/users/[id]/__tests__/route.test.ts
@@ -83,6 +83,20 @@ describe('PUT /api/users/[id]', () => {
     const response = await PUT(request, makeContext('nonexistent'));
     expect(response.status).toBe(404);
   });
+
+  it('returns 409 when updating to an already taken username', async () => {
+    await createUser({ username: 'alice', password: 'pass12345' });
+    const bob = await createUser({ username: 'bob', password: 'pass12345' });
+    const request = new Request('http://localhost', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'alice' }), // already taken
+    });
+    const response = await PUT(request, makeContext(bob.id));
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.code).toBe('CONFLICT');
+  });
 });
 
 describe('DELETE /api/users/[id]', () => {

--- a/src/app/api/users/[id]/__tests__/route.test.ts
+++ b/src/app/api/users/[id]/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { setSetting } from '@/lib/db/settings';
+import { createUser } from '@/lib/db/users';
+import { GET, PUT, DELETE } from '../route';
+
+vi.stubEnv('ENCRYPTION_SECRET', 'a'.repeat(64));
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM users').run();
+  getDb().prepare('DELETE FROM settings').run();
+  setSetting('auth_enabled', true);
+});
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function makeContext(id: string): RouteContext {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/users/[id]', () => {
+  it('returns 403 when auth disabled', async () => {
+    setSetting('auth_enabled', false);
+    const response = await GET(new Request('http://localhost'), makeContext('any-id'));
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await GET(new Request('http://localhost'), makeContext('nonexistent'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns user without password_hash', async () => {
+    const user = await createUser({ username: 'alice', password: 'pass12345' });
+    const response = await GET(new Request('http://localhost'), makeContext(user.id));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.username).toBe('alice');
+    expect(body.data).not.toHaveProperty('password_hash');
+  });
+});
+
+describe('PUT /api/users/[id]', () => {
+  it('updates a user', async () => {
+    const user = await createUser({ username: 'alice', password: 'pass12345' });
+    const request = new Request('http://localhost', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'alicia' }),
+    });
+    const response = await PUT(request, makeContext(user.id));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.username).toBe('alicia');
+  });
+
+  it('returns 400 for empty update body', async () => {
+    const user = await createUser({ username: 'alice', password: 'pass12345' });
+    const request = new Request('http://localhost', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const response = await PUT(request, makeContext(user.id));
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 404 for non-existent user', async () => {
+    const request = new Request('http://localhost', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'new-name' }),
+    });
+    const response = await PUT(request, makeContext('nonexistent'));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/users/[id]', () => {
+  it('deletes a user and returns 204', async () => {
+    const user = await createUser({ username: 'alice', password: 'pass12345' });
+    const response = await DELETE(new Request('http://localhost'), makeContext(user.id));
+    expect(response.status).toBe(204);
+  });
+
+  it('returns 404 for non-existent user', async () => {
+    const response = await DELETE(new Request('http://localhost'), makeContext('nonexistent'));
+    expect(response.status).toBe(404);
+  });
+});

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,24 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getUser, updateUser, deleteUser } from '@/lib/db/users';
-import { getSetting } from '@/lib/db/settings';
 import { UpdateUserSchema } from '@/lib/validators/users';
+import { requireAuth } from '@/lib/auth-guard';
 
 type RouteContext = { params: Promise<{ id: string }> };
-
-function requireAuth(): NextResponse | null {
-  const enabled = getSetting('auth_enabled');
-  if (!enabled) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'User management requires auth to be enabled',
-        code: 'AUTH_NOT_ENABLED',
-      },
-      { status: 403 }
-    );
-  }
-  return null;
-}
 
 export async function GET(_request: Request, { params }: RouteContext) {
   const { id } = await params;
@@ -74,7 +59,14 @@ export async function PUT(request: Request, { params }: RouteContext) {
     }
 
     return NextResponse.json({ success: true, data: updated });
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '';
+    if (message.includes('UNIQUE constraint failed')) {
+      return NextResponse.json(
+        { success: false, error: 'Username already exists', code: 'CONFLICT' },
+        { status: 409 }
+      );
+    }
     return NextResponse.json(
       { success: false, error: 'Failed to update user', code: 'INTERNAL_ERROR' },
       { status: 500 }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { getUser, updateUser, deleteUser } from '@/lib/db/users';
+import { getSetting } from '@/lib/db/settings';
+import { UpdateUserSchema } from '@/lib/validators/users';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function requireAuth(): NextResponse | null {
+  const enabled = getSetting('auth_enabled');
+  if (!enabled) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'User management requires auth to be enabled',
+        code: 'AUTH_NOT_ENABLED',
+      },
+      { status: 403 }
+    );
+  }
+  return null;
+}
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+  try {
+    const authError = requireAuth();
+    if (authError) return authError;
+
+    const user = getUser(id);
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: 'User not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: user });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch user', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: Request, { params }: RouteContext) {
+  const { id } = await params;
+  try {
+    const authError = requireAuth();
+    if (authError) return authError;
+
+    const body = await request.json();
+    const result = UpdateUserSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error.issues.map((i) => i.message).join('; '),
+          code: 'VALIDATION_ERROR',
+        },
+        { status: 400 }
+      );
+    }
+
+    const updated = await updateUser(id, result.data);
+
+    if (!updated) {
+      return NextResponse.json(
+        { success: false, error: 'User not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: updated });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to update user', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+  try {
+    const authError = requireAuth();
+    if (authError) return authError;
+
+    const deleted = deleteUser(id);
+
+    if (!deleted) {
+      return NextResponse.json(
+        { success: false, error: 'User not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    return new Response(null, { status: 204 });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to delete user', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/__tests__/route.test.ts
+++ b/src/app/api/users/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { setSetting } from '@/lib/db/settings';
+import { GET, POST } from '../route';
+
+vi.stubEnv('ENCRYPTION_SECRET', 'a'.repeat(64));
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM users').run();
+  getDb().prepare('DELETE FROM settings').run();
+});
+
+describe('GET /api/users — auth disabled', () => {
+  it('returns 403 when auth_enabled is false', async () => {
+    setSetting('auth_enabled', false);
+    const response = await GET();
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.code).toBe('AUTH_NOT_ENABLED');
+  });
+
+  it('returns 403 when auth_enabled is not set', async () => {
+    const response = await GET();
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('GET /api/users — auth enabled', () => {
+  beforeEach(() => {
+    setSetting('auth_enabled', true);
+  });
+
+  it('returns empty array when no users exist', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, data: [] });
+  });
+
+  it('returns users without password_hash', async () => {
+    await POST(
+      new Request('http://localhost/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'alice', password: 'password123' }),
+      })
+    );
+    const response = await GET();
+    const body = await response.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).not.toHaveProperty('password_hash');
+  });
+});
+
+describe('POST /api/users — auth enabled', () => {
+  beforeEach(() => {
+    setSetting('auth_enabled', true);
+  });
+
+  it('creates a user and returns 201', async () => {
+    const request = new Request('http://localhost/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'alice', password: 'secure123' }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.username).toBe('alice');
+    expect(body.data).not.toHaveProperty('password_hash');
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    const request = new Request('http://localhost/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'alice' }), // missing password
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 409 for duplicate username', async () => {
+    const payload = { username: 'alice', password: 'pass12345' };
+    await POST(
+      new Request('http://localhost/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+    );
+    const response = await POST(
+      new Request('http://localhost/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+    );
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.code).toBe('CONFLICT');
+  });
+
+  it('returns 403 when auth_enabled is false', async () => {
+    setSetting('auth_enabled', false);
+    const request = new Request('http://localhost/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'alice', password: 'pass12345' }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(403);
+  });
+});

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { getUsers, createUser } from '@/lib/db/users';
+import { getSetting } from '@/lib/db/settings';
+import { CreateUserSchema } from '@/lib/validators/users';
+
+function requireAuth(): NextResponse | null {
+  const enabled = getSetting('auth_enabled');
+  if (!enabled) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'User management requires auth to be enabled',
+        code: 'AUTH_NOT_ENABLED',
+      },
+      { status: 403 }
+    );
+  }
+  return null;
+}
+
+export async function GET() {
+  try {
+    const authError = requireAuth();
+    if (authError) return authError;
+
+    return NextResponse.json({ success: true, data: getUsers() });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch users', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const authError = requireAuth();
+    if (authError) return authError;
+
+    const body = await request.json();
+    const result = CreateUserSchema.safeParse(body);
+
+    if (!result.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error.issues.map((i) => i.message).join('; '),
+          code: 'VALIDATION_ERROR',
+        },
+        { status: 400 }
+      );
+    }
+
+    const user = await createUser(result.data);
+    return NextResponse.json({ success: true, data: user }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : '';
+    if (message.includes('UNIQUE constraint failed')) {
+      return NextResponse.json(
+        { success: false, error: 'Username already exists', code: 'CONFLICT' },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { success: false, error: 'Failed to create user', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,22 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getUsers, createUser } from '@/lib/db/users';
-import { getSetting } from '@/lib/db/settings';
 import { CreateUserSchema } from '@/lib/validators/users';
-
-function requireAuth(): NextResponse | null {
-  const enabled = getSetting('auth_enabled');
-  if (!enabled) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'User management requires auth to be enabled',
-        code: 'AUTH_NOT_ENABLED',
-      },
-      { status: 403 }
-    );
-  }
-  return null;
-}
+import { requireAuth } from '@/lib/auth-guard';
 
 export async function GET() {
   try {

--- a/src/lib/__tests__/crypto.test.ts
+++ b/src/lib/__tests__/crypto.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { encrypt, decrypt, SENSITIVE_KEYS, isEncrypted } from '../crypto';
+
+const TEST_KEY = 'a'.repeat(64); // 32-byte key as 64 hex chars
+
+describe('encrypt', () => {
+  it('returns a string in the format iv:authTag:ciphertext', () => {
+    const result = encrypt('my-secret', TEST_KEY);
+    const parts = result.split(':');
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toHaveLength(24); // 12-byte IV as 24 hex chars
+    expect(parts[1]).toHaveLength(32); // 16-byte auth tag as 32 hex chars
+  });
+
+  it('produces different ciphertexts for the same plaintext (random IV)', () => {
+    const a = encrypt('same-value', TEST_KEY);
+    const b = encrypt('same-value', TEST_KEY);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('decrypt', () => {
+  it('round-trips correctly', () => {
+    const encrypted = encrypt('sk-my-openai-key', TEST_KEY);
+    const decrypted = decrypt(encrypted, TEST_KEY);
+    expect(decrypted).toBe('sk-my-openai-key');
+  });
+
+  it('throws on tampered ciphertext', () => {
+    const encrypted = encrypt('value', TEST_KEY);
+    const tampered = encrypted.slice(0, -2) + 'ff';
+    expect(() => decrypt(tampered, TEST_KEY)).toThrow();
+  });
+});
+
+describe('isEncrypted', () => {
+  it('returns true for an encrypted value', () => {
+    const encrypted = encrypt('test', TEST_KEY);
+    expect(isEncrypted(encrypted)).toBe(true);
+  });
+
+  it('returns false for a plain string', () => {
+    expect(isEncrypted('openai')).toBe(false);
+    expect(isEncrypted('none')).toBe(false);
+  });
+});
+
+describe('SENSITIVE_KEYS', () => {
+  it('includes ai_api_key', () => {
+    expect(SENSITIVE_KEYS).toContain('ai_api_key');
+  });
+});

--- a/src/lib/auth-guard.ts
+++ b/src/lib/auth-guard.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getSetting } from '@/lib/db/settings';
+
+export function requireAuth(): NextResponse | null {
+  const enabled = getSetting('auth_enabled');
+  if (!enabled) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'User management requires auth to be enabled',
+        code: 'AUTH_NOT_ENABLED',
+      },
+      { status: 403 }
+    );
+  }
+  return null;
+}

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,68 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+export const SENSITIVE_KEYS = ['ai_api_key'] as const;
+export type SensitiveKey = (typeof SENSITIVE_KEYS)[number];
+
+/**
+ * Returns the 32-byte encryption key as a hex string (64 chars).
+ * Priority: ENCRYPTION_SECRET env var > auto-generated file at ./data/.secret
+ */
+export function getEncryptionKey(): string {
+  if (process.env.ENCRYPTION_SECRET) {
+    const key = process.env.ENCRYPTION_SECRET;
+    if (key.length !== 64) {
+      throw new Error('ENCRYPTION_SECRET must be a 64-character hex string (32 bytes)');
+    }
+    return key;
+  }
+
+  const secretPath = path.resolve('./data/.secret');
+  if (fs.existsSync(secretPath)) {
+    return fs.readFileSync(secretPath, 'utf8').trim();
+  }
+
+  const generated = randomBytes(32).toString('hex');
+  fs.mkdirSync(path.dirname(secretPath), { recursive: true });
+  fs.writeFileSync(secretPath, generated, { mode: 0o600 });
+  console.warn('[a11y-logger] Generated new encryption key at ./data/.secret — keep this safe!');
+  return generated;
+}
+
+/**
+ * Encrypts a plaintext string using AES-256-GCM.
+ * Returns a string in the format: iv:authTag:ciphertext (all hex-encoded).
+ * Accepts an optional key override (used in tests).
+ */
+export function encrypt(plaintext: string, keyHex?: string): string {
+  const key = Buffer.from(keyHex ?? getEncryptionKey(), 'hex');
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [iv.toString('hex'), authTag.toString('hex'), encrypted.toString('hex')].join(':');
+}
+
+/**
+ * Decrypts a value produced by encrypt().
+ * Accepts an optional key override (used in tests).
+ */
+export function decrypt(ciphertext: string, keyHex?: string): string {
+  const key = Buffer.from(keyHex ?? getEncryptionKey(), 'hex');
+  const [ivHex, authTagHex, encryptedHex] = ciphertext.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+  const encrypted = Buffer.from(encryptedHex, 'hex');
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+}
+
+/**
+ * Detects whether a string was produced by encrypt() (iv:authTag:ciphertext format).
+ */
+export function isEncrypted(value: string): boolean {
+  const parts = value.split(':');
+  return parts.length === 3 && parts[0].length === 24 && parts[1].length === 32;
+}

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -50,7 +50,11 @@ export function encrypt(plaintext: string, keyHex?: string): string {
  */
 export function decrypt(ciphertext: string, keyHex?: string): string {
   const key = Buffer.from(keyHex ?? getEncryptionKey(), 'hex');
-  const [ivHex, authTagHex, encryptedHex] = ciphertext.split(':');
+  const parts = ciphertext.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid ciphertext format — expected iv:authTag:ciphertext');
+  }
+  const [ivHex, authTagHex, encryptedHex] = parts as [string, string, string];
   const iv = Buffer.from(ivHex, 'hex');
   const authTag = Buffer.from(authTagHex, 'hex');
   const encrypted = Buffer.from(encryptedHex, 'hex');
@@ -64,5 +68,7 @@ export function decrypt(ciphertext: string, keyHex?: string): string {
  */
 export function isEncrypted(value: string): boolean {
   const parts = value.split(':');
-  return parts.length === 3 && parts[0].length === 24 && parts[1].length === 32;
+  if (parts.length !== 3) return false;
+  const [iv, authTag] = parts as [string, string, string];
+  return iv.length === 24 && authTag.length === 32;
 }

--- a/src/lib/db/__tests__/settings.test.ts
+++ b/src/lib/db/__tests__/settings.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import { initDb, closeDb, getDb } from '../index';
+import {
+  getSetting,
+  setSetting,
+  getSettings,
+  deleteSetting,
+  seedDefaultSettings,
+} from '../settings';
+
+// Use a fixed encryption key so tests don't touch the filesystem
+vi.stubEnv('ENCRYPTION_SECRET', 'a'.repeat(64));
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM settings').run();
+});
+
+describe('setSetting / getSetting', () => {
+  it('stores and retrieves a string value', () => {
+    setSetting('ai_provider', 'openai');
+    expect(getSetting('ai_provider')).toBe('openai');
+  });
+
+  it('stores and retrieves a boolean value', () => {
+    setSetting('auth_enabled', true);
+    expect(getSetting('auth_enabled')).toBe(true);
+  });
+
+  it('stores and retrieves a numeric value', () => {
+    setSetting('schema_version', 1);
+    expect(getSetting('schema_version')).toBe(1);
+  });
+
+  it('upserts an existing key', () => {
+    setSetting('ai_provider', 'openai');
+    setSetting('ai_provider', 'anthropic');
+    expect(getSetting('ai_provider')).toBe('anthropic');
+  });
+
+  it('returns null for a key that does not exist', () => {
+    expect(getSetting('nonexistent')).toBeNull();
+  });
+
+  it('encrypts sensitive keys (ai_api_key stored as encrypted format)', () => {
+    setSetting('ai_api_key', 'sk-test-123');
+    const raw = getDb().prepare("SELECT value FROM settings WHERE key = 'ai_api_key'").get() as {
+      value: string;
+    };
+    // Raw value should be JSON-stringified encrypted string, not the plain key
+    const stored = JSON.parse(raw.value);
+    expect(stored).not.toBe('sk-test-123');
+    expect(stored.split(':')).toHaveLength(3); // iv:authTag:ciphertext
+  });
+
+  it('decrypts sensitive keys on retrieval', () => {
+    setSetting('ai_api_key', 'sk-test-456');
+    expect(getSetting('ai_api_key')).toBe('sk-test-456');
+  });
+});
+
+describe('getSettings', () => {
+  it('returns an empty object when no settings exist', () => {
+    expect(getSettings()).toEqual({});
+  });
+
+  it('returns all settings as a key-value map', () => {
+    setSetting('ai_provider', 'openai');
+    setSetting('auth_enabled', false);
+    const all = getSettings();
+    expect(all.ai_provider).toBe('openai');
+    expect(all.auth_enabled).toBe(false);
+  });
+
+  it('redacts sensitive keys in the returned object', () => {
+    setSetting('ai_api_key', 'sk-real-key');
+    const all = getSettings();
+    expect(all.ai_api_key).toBe('[REDACTED]');
+  });
+});
+
+describe('deleteSetting', () => {
+  it('removes the setting', () => {
+    setSetting('ai_provider', 'openai');
+    deleteSetting('ai_provider');
+    expect(getSetting('ai_provider')).toBeNull();
+  });
+
+  it('does not throw when deleting a non-existent key', () => {
+    expect(() => deleteSetting('nonexistent')).not.toThrow();
+  });
+});
+
+describe('seedDefaultSettings', () => {
+  it('seeds all default settings when none exist', () => {
+    seedDefaultSettings();
+    expect(getSetting('ai_provider')).toBe('none');
+    expect(getSetting('auth_enabled')).toBe(false);
+    expect(getSetting('media_directory')).toBe('./data/media');
+  });
+
+  it('does not overwrite existing settings', () => {
+    setSetting('ai_provider', 'openai');
+    seedDefaultSettings();
+    expect(getSetting('ai_provider')).toBe('openai'); // not overwritten
+  });
+});

--- a/src/lib/db/__tests__/users.test.ts
+++ b/src/lib/db/__tests__/users.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '../index';
+import { getUsers, getUser, getUserByUsername, createUser, updateUser, deleteUser } from '../users';
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  getDb().prepare('DELETE FROM users').run();
+});
+
+describe('createUser', () => {
+  it('inserts a user and returns it without password_hash', async () => {
+    const user = await createUser({ username: 'alice', password: 'secure123', role: 'admin' });
+    expect(user.id).toBeDefined();
+    expect(user.username).toBe('alice');
+    expect(user.role).toBe('admin');
+    expect(user).not.toHaveProperty('password_hash');
+  });
+
+  it('defaults role to member', async () => {
+    const user = await createUser({ username: 'bob', password: 'pass' });
+    expect(user.role).toBe('member');
+  });
+
+  it('throws when username already exists', async () => {
+    await createUser({ username: 'alice', password: 'pass' });
+    await expect(createUser({ username: 'alice', password: 'pass' })).rejects.toThrow();
+  });
+
+  it('hashes the password (does not store plaintext)', async () => {
+    await createUser({ username: 'carol', password: 'mypassword' });
+    const row = getDb()
+      .prepare("SELECT password_hash FROM users WHERE username = 'carol'")
+      .get() as { password_hash: string };
+    expect(row.password_hash).not.toBe('mypassword');
+    expect(row.password_hash).toMatch(/^\$2[aby]\$/); // bcrypt hash prefix
+  });
+});
+
+describe('getUsers', () => {
+  it('returns empty array when no users exist', async () => {
+    expect(getUsers()).toEqual([]);
+  });
+
+  it('returns all users without password_hash', async () => {
+    await createUser({ username: 'alice', password: 'pass' });
+    await createUser({ username: 'bob', password: 'pass' });
+    const users = getUsers();
+    expect(users).toHaveLength(2);
+    users.forEach((u) => expect(u).not.toHaveProperty('password_hash'));
+  });
+});
+
+describe('getUser', () => {
+  it('returns a user by id without password_hash', async () => {
+    const created = await createUser({ username: 'alice', password: 'pass' });
+    const found = getUser(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.username).toBe('alice');
+    expect(found).not.toHaveProperty('password_hash');
+  });
+
+  it('returns null for non-existent id', () => {
+    expect(getUser('nonexistent-id')).toBeNull();
+  });
+});
+
+describe('getUserByUsername', () => {
+  it('returns the full row including password_hash (for auth verification)', async () => {
+    await createUser({ username: 'alice', password: 'secret' });
+    const found = getUserByUsername('alice');
+    expect(found).not.toBeNull();
+    expect(found!.password_hash).toBeDefined();
+  });
+
+  it('returns null when not found', () => {
+    expect(getUserByUsername('nobody')).toBeNull();
+  });
+});
+
+describe('updateUser', () => {
+  it('updates the username', async () => {
+    const created = await createUser({ username: 'alice', password: 'pass' });
+    const updated = await updateUser(created.id, { username: 'alicia' });
+    expect(updated!.username).toBe('alicia');
+  });
+
+  it('re-hashes the password when updated', async () => {
+    const created = await createUser({ username: 'alice', password: 'old-pass' });
+    await updateUser(created.id, { password: 'new-pass' });
+    const row = getDb().prepare('SELECT password_hash FROM users WHERE id = ?').get(created.id) as {
+      password_hash: string;
+    };
+    expect(row.password_hash).toMatch(/^\$2[aby]\$/);
+    // verify new password actually works
+    const bcrypt = await import('bcryptjs');
+    expect(await bcrypt.compare('new-pass', row.password_hash)).toBe(true);
+  });
+
+  it('returns null for non-existent id', async () => {
+    expect(await updateUser('nonexistent', { username: 'x' })).toBeNull();
+  });
+
+  it('does not change untouched fields', async () => {
+    const created = await createUser({ username: 'alice', password: 'pass', role: 'admin' });
+    const updated = await updateUser(created.id, { username: 'alicia' });
+    expect(updated!.role).toBe('admin');
+  });
+});
+
+describe('deleteUser', () => {
+  it('removes the user', async () => {
+    const created = await createUser({ username: 'alice', password: 'pass' });
+    deleteUser(created.id);
+    expect(getUser(created.id)).toBeNull();
+  });
+
+  it('does not throw for non-existent id', () => {
+    expect(() => deleteUser('nonexistent')).not.toThrow();
+  });
+});

--- a/src/lib/db/__tests__/users.test.ts
+++ b/src/lib/db/__tests__/users.test.ts
@@ -125,4 +125,13 @@ describe('deleteUser', () => {
   it('does not throw for non-existent id', () => {
     expect(() => deleteUser('nonexistent')).not.toThrow();
   });
+
+  it('returns true when the user was deleted', async () => {
+    const created = await createUser({ username: 'alice', password: 'pass' });
+    expect(deleteUser(created.id)).toBe(true);
+  });
+
+  it('returns false when user does not exist', () => {
+    expect(deleteUser('nonexistent-id')).toBe(false);
+  });
 });

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { runMigrations } from './migrate';
 import { loadMigrations } from './load-migrations';
+import { seedDefaultSettings } from './settings';
 
 let db: Database.Database | null = null;
 
@@ -35,6 +36,7 @@ export function initDb(dbPath?: string): Database.Database {
   const database = getDb(dbPath);
   const migrations = loadMigrations(MIGRATIONS_DIR);
   runMigrations(database, migrations);
+  seedDefaultSettings();
   return database;
 }
 

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -1,0 +1,84 @@
+import { getDb } from './index';
+import { encrypt, decrypt, SENSITIVE_KEYS, isEncrypted } from '../crypto';
+
+type SettingValue = string | number | boolean | null;
+
+interface SettingRow {
+  key: string;
+  value: string; // JSON-serialized
+}
+
+const DEFAULT_SETTINGS: Record<string, SettingValue> = {
+  ai_provider: 'none',
+  ai_api_key: '',
+  media_directory: './data/media',
+  auth_enabled: false,
+  app_version: '1.0.0',
+  schema_version: 1,
+};
+
+function isSensitiveKey(key: string): key is (typeof SENSITIVE_KEYS)[number] {
+  return (SENSITIVE_KEYS as readonly string[]).includes(key);
+}
+
+export function getSetting(key: string): SettingValue {
+  const row = getDb().prepare('SELECT value FROM settings WHERE key = ?').get(key) as
+    | SettingRow
+    | undefined;
+
+  if (!row) return null;
+
+  const parsed = JSON.parse(row.value) as SettingValue;
+
+  if (isSensitiveKey(key) && typeof parsed === 'string' && isEncrypted(parsed)) {
+    return decrypt(parsed);
+  }
+
+  return parsed;
+}
+
+export function setSetting(key: string, value: SettingValue): void {
+  let stored: SettingValue = value;
+
+  if (isSensitiveKey(key) && typeof value === 'string' && value !== '') {
+    stored = encrypt(value);
+  }
+
+  getDb()
+    .prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')
+    .run(key, JSON.stringify(stored));
+}
+
+export function getSettings(): Record<string, SettingValue> {
+  const rows = getDb().prepare('SELECT key, value FROM settings').all() as SettingRow[];
+  const result: Record<string, SettingValue> = {};
+
+  for (const row of rows) {
+    const parsed = JSON.parse(row.value) as SettingValue;
+
+    if (isSensitiveKey(row.key)) {
+      result[row.key] = '[REDACTED]';
+    } else {
+      result[row.key] = parsed;
+    }
+  }
+
+  return result;
+}
+
+export function deleteSetting(key: string): void {
+  getDb().prepare('DELETE FROM settings WHERE key = ?').run(key);
+}
+
+export function seedDefaultSettings(): void {
+  const db = getDb();
+  const existing = new Set(
+    (db.prepare('SELECT key FROM settings').all() as { key: string }[]).map((r) => r.key)
+  );
+
+  for (const [key, value] of Object.entries(DEFAULT_SETTINGS)) {
+    if (!existing.has(key)) {
+      setSetting(key, value);
+    }
+  }
+}

--- a/src/lib/db/settings.ts
+++ b/src/lib/db/settings.ts
@@ -28,7 +28,12 @@ export function getSetting(key: string): SettingValue {
 
   if (!row) return null;
 
-  const parsed = JSON.parse(row.value) as SettingValue;
+  let parsed: SettingValue;
+  try {
+    parsed = JSON.parse(row.value) as SettingValue;
+  } catch {
+    return null;
+  }
 
   if (isSensitiveKey(key) && typeof parsed === 'string' && isEncrypted(parsed)) {
     return decrypt(parsed);
@@ -54,7 +59,12 @@ export function getSettings(): Record<string, SettingValue> {
   const result: Record<string, SettingValue> = {};
 
   for (const row of rows) {
-    const parsed = JSON.parse(row.value) as SettingValue;
+    let parsed: SettingValue;
+    try {
+      parsed = JSON.parse(row.value) as SettingValue;
+    } catch {
+      continue;
+    }
 
     if (isSensitiveKey(row.key)) {
       result[row.key] = '[REDACTED]';

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -1,0 +1,92 @@
+import bcrypt from 'bcryptjs';
+import { getDb } from './index';
+import type { CreateUserInput, UpdateUserInput } from '../validators/users';
+
+export interface User {
+  id: string;
+  username: string;
+  role: 'admin' | 'member';
+  created_at: string;
+  updated_at: string;
+}
+
+// Full row including password_hash — only for internal auth use
+export interface UserWithHash extends User {
+  password_hash: string;
+}
+
+const BCRYPT_ROUNDS = 12;
+
+const SELECT_WITHOUT_HASH = `
+  SELECT id, username, role, created_at, updated_at FROM users
+`;
+
+export function getUsers(): User[] {
+  return getDb().prepare(`${SELECT_WITHOUT_HASH} ORDER BY created_at DESC`).all() as User[];
+}
+
+export function getUser(id: string): User | null {
+  return (
+    (getDb().prepare(`${SELECT_WITHOUT_HASH} WHERE id = ?`).get(id) as User | undefined) ?? null
+  );
+}
+
+export function getUserByUsername(username: string): UserWithHash | null {
+  return (
+    (getDb().prepare('SELECT * FROM users WHERE username = ?').get(username) as
+      | UserWithHash
+      | undefined) ?? null
+  );
+}
+
+export async function createUser(input: CreateUserInput): Promise<User> {
+  const id = crypto.randomUUID();
+  const passwordHash = await bcrypt.hash(input.password, BCRYPT_ROUNDS);
+
+  getDb()
+    .prepare(
+      `INSERT INTO users (id, username, password_hash, role)
+       VALUES (?, ?, ?, ?)`
+    )
+    .run(id, input.username, passwordHash, input.role ?? 'member');
+
+  return getUser(id)!;
+}
+
+export async function updateUser(id: string, input: UpdateUserInput): Promise<User | null> {
+  const existing = getUser(id);
+  if (!existing) return null;
+
+  const fields: string[] = [];
+  const values: unknown[] = [];
+
+  if (input.username !== undefined) {
+    fields.push('username = ?');
+    values.push(input.username);
+  }
+
+  if (input.password !== undefined) {
+    fields.push('password_hash = ?');
+    values.push(await bcrypt.hash(input.password, BCRYPT_ROUNDS));
+  }
+
+  if (input.role !== undefined) {
+    fields.push('role = ?');
+    values.push(input.role);
+  }
+
+  if (fields.length === 0) return existing;
+
+  fields.push("updated_at = datetime('now')");
+  values.push(id);
+
+  getDb()
+    .prepare(`UPDATE users SET ${fields.join(', ')} WHERE id = ?`)
+    .run(...values);
+
+  return getUser(id);
+}
+
+export function deleteUser(id: string): void {
+  getDb().prepare('DELETE FROM users WHERE id = ?').run(id);
+}

--- a/src/lib/db/users.ts
+++ b/src/lib/db/users.ts
@@ -87,6 +87,7 @@ export async function updateUser(id: string, input: UpdateUserInput): Promise<Us
   return getUser(id);
 }
 
-export function deleteUser(id: string): void {
-  getDb().prepare('DELETE FROM users WHERE id = ?').run(id);
+export function deleteUser(id: string): boolean {
+  const result = getDb().prepare('DELETE FROM users WHERE id = ?').run(id);
+  return result.changes > 0;
 }

--- a/src/lib/validators/settings.ts
+++ b/src/lib/validators/settings.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const SettingValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+
+export const UpdateSettingSchema = z.object({
+  value: SettingValueSchema,
+});
+
+export const BatchUpdateSettingsSchema = z.record(z.string(), SettingValueSchema);
+
+export type SettingValue = z.infer<typeof SettingValueSchema>;
+export type UpdateSettingInput = z.infer<typeof UpdateSettingSchema>;
+export type BatchUpdateSettingsInput = z.infer<typeof BatchUpdateSettingsSchema>;

--- a/src/lib/validators/users.ts
+++ b/src/lib/validators/users.ts
@@ -1,0 +1,11 @@
+export interface CreateUserInput {
+  username: string;
+  password: string;
+  role?: 'admin' | 'member';
+}
+
+export interface UpdateUserInput {
+  username?: string;
+  password?: string;
+  role?: 'admin' | 'member';
+}

--- a/src/lib/validators/users.ts
+++ b/src/lib/validators/users.ts
@@ -1,11 +1,20 @@
-export interface CreateUserInput {
-  username: string;
-  password: string;
-  role?: 'admin' | 'member';
-}
+import { z } from 'zod';
 
-export interface UpdateUserInput {
-  username?: string;
-  password?: string;
-  role?: 'admin' | 'member';
-}
+export const CreateUserSchema = z.object({
+  username: z.string().min(1).max(50),
+  password: z.string().min(8).max(100),
+  role: z.enum(['admin', 'member']).optional(),
+});
+
+export const UpdateUserSchema = z
+  .object({
+    username: z.string().min(1).max(50).optional(),
+    password: z.string().min(8).max(100).optional(),
+    role: z.enum(['admin', 'member']).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export type CreateUserInput = z.infer<typeof CreateUserSchema>;
+export type UpdateUserInput = z.infer<typeof UpdateUserSchema>;


### PR DESCRIPTION
### Summary

This pull request introduces APIs for managing settings and users securely, with authentication and data encryption. Major changes include:

- **Settings API**: Added `/api/settings` endpoints supporting GET and PUT operations, with sensitive keys `[REDACTED]` in responses. Includes encryption for secure storage.
- **Users API**: Added routes that are gated behind the `auth_enabled` configuration, including password hashing with bcrypt for secure management.
- **Validators**: Integrated Zod schemas for both settings and users for stricter validation.
- **Encryption Utility**: Added AES-256-GCM encryption for handling sensitive settings like API keys.
- **Default Seeding**: Seeded default settings upon database initialization.
- **Code Refactoring and Fixes**: Introduced shared `requireAuth`, improved request handling, and fixed TypeScript and runtime errors.