### PR TITLE
feat(#13): add assessments UI with status transitions

### DIFF
--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/edit/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/edit/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+import { useParams, useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
+import { ChevronLeft } from 'lucide-react';
+import Link from 'next/link';
+import { AssessmentForm } from '@/components/assessments/assessment-form';
+import type { Assessment } from '@/lib/db/assessments';
+
+interface AssessmentFormData {
+  name: string;
+  description: string;
+  test_date_start: string;
+  test_date_end: string;
+  status: 'planning' | 'in_progress' | 'completed';
+}
+
+export default function EditAssessmentPage() {
+  const params = useParams();
+  const projectId = params.projectId as string;
+  const assessmentId = params.assessmentId as string;
+  const router = useRouter();
+
+  const [assessment, setAssessment] = useState<Assessment | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/projects/${projectId}/assessments/${assessmentId}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.success) setAssessment(json.data);
+        else toast.error('Failed to load assessment');
+      })
+      .catch(() => toast.error('Failed to load assessment'))
+      .finally(() => setFetching(false));
+  }, [projectId, assessmentId]);
+
+  const handleSubmit = async (data: AssessmentFormData) => {
+    setLoading(true);
+    try {
+      const payload: Record<string, unknown> = {
+        name: data.name,
+        status: data.status,
+      };
+      if (data.description !== undefined) payload.description = data.description;
+      if (data.test_date_start)
+        payload.test_date_start = new Date(data.test_date_start).toISOString();
+      if (data.test_date_end) payload.test_date_end = new Date(data.test_date_end).toISOString();
+
+      const res = await fetch(`/api/projects/${projectId}/assessments/${assessmentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success('Assessment updated');
+      router.push(`/projects/${projectId}/assessments/${assessmentId}`);
+    } catch {
+      toast.error('Failed to update assessment');
+      setLoading(false);
+    }
+  };
+
+  if (fetching) {
+    return <div className="p-6 text-muted-foreground">Loading…</div>;
+  }
+
+  if (!assessment) {
+    return <div className="p-6 text-destructive">Assessment not found.</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href={`/projects/${projectId}/assessments/${assessmentId}`}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to Assessment
+      </Link>
+      <h1 className="text-2xl font-bold">Edit Assessment</h1>
+      <AssessmentForm assessment={assessment} onSubmit={handleSubmit} loading={loading} />
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/edit/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/edit/page.tsx
@@ -5,15 +5,8 @@ import { toast } from 'sonner';
 import { ChevronLeft } from 'lucide-react';
 import Link from 'next/link';
 import { AssessmentForm } from '@/components/assessments/assessment-form';
+import type { AssessmentFormData } from '@/components/assessments/assessment-form';
 import type { Assessment } from '@/lib/db/assessments';
-
-interface AssessmentFormData {
-  name: string;
-  description: string;
-  test_date_start: string;
-  test_date_end: string;
-  status: 'planning' | 'in_progress' | 'completed';
-}
 
 export default function EditAssessmentPage() {
   const params = useParams();

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/page.tsx
@@ -55,12 +55,9 @@ export default async function AssessmentDetailPage({
 }) {
   const { projectId, assessmentId } = await params;
 
-  const [project, assessment] = await Promise.all([
-    Promise.resolve(getProject(projectId)),
-    Promise.resolve(getAssessment(assessmentId)),
-  ]);
-
+  const project = getProject(projectId);
   if (!project) notFound();
+  const assessment = getAssessment(assessmentId);
   if (!assessment) notFound();
 
   const issues = getIssues(assessmentId);

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/page.tsx
@@ -1,0 +1,206 @@
+import Link from 'next/link';
+import { Pencil } from 'lucide-react';
+import { notFound } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { getProject } from '@/lib/db/projects';
+import { getAssessment } from '@/lib/db/assessments';
+import { getIssues } from '@/lib/db/issues';
+import { DeleteAssessmentButton } from '@/components/assessments/delete-assessment-button';
+import { StatusTransitionButton } from '@/components/assessments/status-transition-button';
+
+export const dynamic = 'force-dynamic';
+
+const statusConfig = {
+  planning: { label: 'Planning', className: 'bg-gray-100 text-gray-700' },
+  in_progress: { label: 'In Progress', className: 'bg-blue-100 text-blue-700' },
+  completed: { label: 'Completed', className: 'bg-green-100 text-green-700' },
+};
+
+const severityConfig = {
+  critical: { label: 'Critical', className: 'bg-red-100 text-red-700' },
+  high: { label: 'High', className: 'bg-orange-100 text-orange-700' },
+  medium: { label: 'Medium', className: 'bg-yellow-100 text-yellow-700' },
+  low: { label: 'Low', className: 'bg-blue-100 text-blue-700' },
+};
+
+const issueStatusLabels: Record<string, string> = {
+  open: 'Open',
+  resolved: 'Resolved',
+  wont_fix: "Won't Fix",
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export default async function AssessmentDetailPage({
+  params,
+}: {
+  params: Promise<{ projectId: string; assessmentId: string }>;
+}) {
+  const { projectId, assessmentId } = await params;
+
+  const [project, assessment] = await Promise.all([
+    Promise.resolve(getProject(projectId)),
+    Promise.resolve(getAssessment(assessmentId)),
+  ]);
+
+  if (!project) notFound();
+  if (!assessment) notFound();
+
+  const issues = getIssues(assessmentId);
+
+  const severityCounts = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const issue of issues) {
+    severityCounts[issue.severity]++;
+  }
+
+  const status = statusConfig[assessment.status];
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-1 text-sm text-muted-foreground">
+        <Link href="/projects" className="hover:text-foreground">
+          Projects
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}`} className="hover:text-foreground">
+          {project.name}
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}/assessments`} className="hover:text-foreground">
+          Assessments
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">{assessment.name}</span>
+      </nav>
+
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold">{assessment.name}</h1>
+            <Badge className={status.className}>{status.label}</Badge>
+          </div>
+          {assessment.description && (
+            <p className="text-muted-foreground">{assessment.description}</p>
+          )}
+          <p className="text-sm text-muted-foreground">
+            {formatDate(assessment.test_date_start)} — {formatDate(assessment.test_date_end)}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <StatusTransitionButton
+            projectId={projectId}
+            assessmentId={assessmentId}
+            currentStatus={assessment.status}
+          />
+          <Button variant="outline" asChild>
+            <Link href={`/projects/${projectId}/assessments/${assessmentId}/edit`}>
+              <Pencil className="mr-2 h-4 w-4" />
+              Edit
+            </Link>
+          </Button>
+          <DeleteAssessmentButton
+            projectId={projectId}
+            assessmentId={assessmentId}
+            assessmentName={assessment.name}
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-6">
+        {/* Issues table */}
+        <div className="flex-1">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <CardTitle>Issues ({issues.length})</CardTitle>
+              <Button asChild size="sm">
+                <Link href={`/projects/${projectId}/assessments/${assessmentId}/issues/new`}>
+                  Add Issue
+                </Link>
+              </Button>
+            </CardHeader>
+            <CardContent>
+              {issues.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-8">No issues yet.</p>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Title</TableHead>
+                      <TableHead>Severity</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Created</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {issues.map((issue) => {
+                      const sev = severityConfig[issue.severity];
+                      return (
+                        <TableRow key={issue.id}>
+                          <TableCell className="font-medium">{issue.title}</TableCell>
+                          <TableCell>
+                            <Badge className={sev.className}>{sev.label}</Badge>
+                          </TableCell>
+                          <TableCell>{issueStatusLabels[issue.status] ?? issue.status}</TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {formatDate(issue.created_at)}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <aside className="w-64 shrink-0 space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Issue Severity</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {[
+                { key: 'critical', label: 'Critical', color: 'text-red-500' },
+                { key: 'high', label: 'High', color: 'text-orange-500' },
+                { key: 'medium', label: 'Medium', color: 'text-yellow-500' },
+                { key: 'low', label: 'Low', color: 'text-blue-500' },
+              ].map(({ key, label, color }) => (
+                <div key={key} className="flex justify-between text-sm">
+                  <span className={`font-medium ${color}`}>{label}</span>
+                  <span className="font-bold">
+                    {severityCounts[key as keyof typeof severityCounts]}
+                  </span>
+                </div>
+              ))}
+              <div className="border-t pt-2 flex justify-between text-sm">
+                <span className="text-muted-foreground">Total</span>
+                <span className="font-bold">{issues.length}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/assessments/new/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/new/page.tsx
@@ -5,14 +5,7 @@ import { toast } from 'sonner';
 import { ChevronLeft } from 'lucide-react';
 import Link from 'next/link';
 import { AssessmentForm } from '@/components/assessments/assessment-form';
-
-interface AssessmentFormData {
-  name: string;
-  description: string;
-  test_date_start: string;
-  test_date_end: string;
-  status: 'planning' | 'in_progress' | 'completed';
-}
+import type { AssessmentFormData } from '@/components/assessments/assessment-form';
 
 export default function NewAssessmentPage() {
   const params = useParams();
@@ -27,7 +20,7 @@ export default function NewAssessmentPage() {
         name: data.name,
         status: data.status,
       };
-      if (data.description) payload.description = data.description;
+      if (data.description !== undefined) payload.description = data.description;
       if (data.test_date_start)
         payload.test_date_start = new Date(data.test_date_start).toISOString();
       if (data.test_date_end) payload.test_date_end = new Date(data.test_date_end).toISOString();

--- a/src/app/(app)/projects/[projectId]/assessments/new/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/new/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useParams, useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { ChevronLeft } from 'lucide-react';
+import Link from 'next/link';
+import { AssessmentForm } from '@/components/assessments/assessment-form';
+
+interface AssessmentFormData {
+  name: string;
+  description: string;
+  test_date_start: string;
+  test_date_end: string;
+  status: 'planning' | 'in_progress' | 'completed';
+}
+
+export default function NewAssessmentPage() {
+  const params = useParams();
+  const projectId = params.projectId as string;
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (data: AssessmentFormData) => {
+    setLoading(true);
+    try {
+      const payload: Record<string, unknown> = {
+        name: data.name,
+        status: data.status,
+      };
+      if (data.description) payload.description = data.description;
+      if (data.test_date_start)
+        payload.test_date_start = new Date(data.test_date_start).toISOString();
+      if (data.test_date_end) payload.test_date_end = new Date(data.test_date_end).toISOString();
+
+      const res = await fetch(`/api/projects/${projectId}/assessments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success('Assessment created');
+      router.push(`/projects/${projectId}/assessments/${json.data.id}`);
+    } catch {
+      toast.error('Failed to create assessment');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href={`/projects/${projectId}/assessments`}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to Assessments
+      </Link>
+      <h1 className="text-2xl font-bold">New Assessment</h1>
+      <AssessmentForm onSubmit={handleSubmit} loading={loading} />
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/assessments/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/page.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { ChevronLeft, Plus } from 'lucide-react';
+import { notFound } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { getProject } from '@/lib/db/projects';
+import { getAssessments } from '@/lib/db/assessments';
+import { AssessmentCard } from '@/components/assessments/assessment-card';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AssessmentsPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>;
+}) {
+  const { projectId } = await params;
+  const project = getProject(projectId);
+  if (!project) notFound();
+
+  const assessments = getAssessments(projectId);
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href={`/projects/${projectId}`}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to project
+      </Link>
+
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Assessments — {project.name}</h1>
+        <Button asChild>
+          <Link href={`/projects/${projectId}/assessments/new`}>
+            <Plus className="mr-2 h-4 w-4" />
+            New Assessment
+          </Link>
+        </Button>
+      </div>
+
+      {assessments.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <p className="text-muted-foreground">No assessments yet.</p>
+          <Button asChild className="mt-4">
+            <Link href={`/projects/${projectId}/assessments/new`}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create your first assessment
+            </Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {assessments.map((assessment) => (
+            <AssessmentCard key={assessment.id} assessment={assessment} projectId={projectId} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -7,6 +7,8 @@ import { getProject } from '@/lib/db/projects';
 import { getIssuesByProject } from '@/lib/db/issues';
 import { DeleteProjectButton } from '@/components/projects/delete-project-button';
 
+export const dynamic = 'force-dynamic';
+
 export default async function ProjectDetailPage({
   params,
 }: {

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button';
 import { ProjectCard } from '@/components/projects/project-card';
 import { getProjects } from '@/lib/db/projects';
 
+export const dynamic = 'force-dynamic';
+
 export default function ProjectsPage() {
   const projects = getProjects();
   return (

--- a/src/components/__tests__/assessments/assessment-card.test.tsx
+++ b/src/components/__tests__/assessments/assessment-card.test.tsx
@@ -53,3 +53,15 @@ test('shows completed status badge', () => {
   render(<AssessmentCard assessment={completed} projectId="p1" />);
   expect(screen.getByText(/completed/i)).toBeInTheDocument();
 });
+
+test('shows formatted date range', () => {
+  render(<AssessmentCard assessment={mockAssessment} projectId="p1" />);
+  expect(screen.getByText(/jan/i)).toBeInTheDocument();
+});
+
+test('planning badge has gray style', () => {
+  const planning = { ...mockAssessment, status: 'planning' as const };
+  render(<AssessmentCard assessment={planning} projectId="p1" />);
+  const badge = screen.getByText(/planning/i);
+  expect(badge).toHaveClass('bg-gray-100');
+});

--- a/src/components/__tests__/assessments/assessment-card.test.tsx
+++ b/src/components/__tests__/assessments/assessment-card.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { AssessmentCard } from '@/components/assessments/assessment-card';
+import type { AssessmentWithCounts } from '@/lib/db/assessments';
+
+const mockAssessment: AssessmentWithCounts = {
+  id: '1',
+  project_id: 'p1',
+  name: 'Mobile Audit Q1',
+  description: 'Full audit of mobile app',
+  test_date_start: '2026-01-01T00:00:00.000Z',
+  test_date_end: '2026-01-31T00:00:00.000Z',
+  status: 'in_progress',
+  assigned_to: null,
+  created_by: null,
+  created_at: '2026-01-01T00:00:00',
+  updated_at: '2026-01-01T00:00:00',
+  issue_count: 5,
+};
+
+test('renders assessment name', () => {
+  render(<AssessmentCard assessment={mockAssessment} projectId="p1" />);
+  expect(screen.getByText('Mobile Audit Q1')).toBeInTheDocument();
+});
+
+test('renders assessment description', () => {
+  render(<AssessmentCard assessment={mockAssessment} projectId="p1" />);
+  expect(screen.getByText('Full audit of mobile app')).toBeInTheDocument();
+});
+
+test('shows status badge', () => {
+  render(<AssessmentCard assessment={mockAssessment} projectId="p1" />);
+  expect(screen.getByText(/in.progress/i)).toBeInTheDocument();
+});
+
+test('shows issue count', () => {
+  render(<AssessmentCard assessment={mockAssessment} projectId="p1" />);
+  expect(screen.getByText(/5 issues/i)).toBeInTheDocument();
+});
+
+test('links to assessment detail', () => {
+  render(<AssessmentCard assessment={mockAssessment} projectId="p1" />);
+  expect(screen.getByRole('link')).toHaveAttribute('href', '/projects/p1/assessments/1');
+});
+
+test('shows planning status badge with correct style', () => {
+  const planning = { ...mockAssessment, status: 'planning' as const };
+  render(<AssessmentCard assessment={planning} projectId="p1" />);
+  expect(screen.getByText(/planning/i)).toBeInTheDocument();
+});
+
+test('shows completed status badge', () => {
+  const completed = { ...mockAssessment, status: 'completed' as const };
+  render(<AssessmentCard assessment={completed} projectId="p1" />);
+  expect(screen.getByText(/completed/i)).toBeInTheDocument();
+});

--- a/src/components/__tests__/assessments/assessment-form.test.tsx
+++ b/src/components/__tests__/assessments/assessment-form.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { AssessmentForm } from '@/components/assessments/assessment-form';
+import type { Assessment } from '@/lib/db/assessments';
+
+test('renders name field as required', () => {
+  render(<AssessmentForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/name/i)).toBeRequired();
+});
+
+test('renders description textarea', () => {
+  render(<AssessmentForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+});
+
+test('renders start date field', () => {
+  render(<AssessmentForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
+});
+
+test('renders end date field', () => {
+  render(<AssessmentForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+});
+
+test('renders status select', () => {
+  render(<AssessmentForm onSubmit={vi.fn()} />);
+  expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument();
+});
+
+test('renders save button', () => {
+  render(<AssessmentForm onSubmit={vi.fn()} />);
+  expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+});
+
+test('calls onSubmit with form data', () => {
+  const onSubmit = vi.fn();
+  render(<AssessmentForm onSubmit={onSubmit} />);
+  fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Q1 Audit' } });
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ name: 'Q1 Audit' }));
+});
+
+test('pre-fills with existing assessment data', () => {
+  const assessment: Assessment = {
+    id: '1',
+    project_id: 'p1',
+    name: 'Existing Audit',
+    description: 'Existing description',
+    test_date_start: '2026-01-01T00:00:00.000Z',
+    test_date_end: '2026-01-31T00:00:00.000Z',
+    status: 'in_progress',
+    assigned_to: null,
+    created_by: null,
+    created_at: '2026-01-01T00:00:00',
+    updated_at: '2026-01-01T00:00:00',
+  };
+  render(<AssessmentForm assessment={assessment} onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/name/i)).toHaveValue('Existing Audit');
+  expect(screen.getByLabelText(/description/i)).toHaveValue('Existing description');
+});

--- a/src/components/__tests__/assessments/delete-assessment-button.test.tsx
+++ b/src/components/__tests__/assessments/delete-assessment-button.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+// Mock sonner
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// Mock fetch
+global.fetch = vi.fn();
+
+import { DeleteAssessmentButton } from '@/components/assessments/delete-assessment-button';
+import { toast } from 'sonner';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders the Delete trigger button', () => {
+  render(
+    <DeleteAssessmentButton projectId="p1" assessmentId="a1" assessmentName="Mobile Audit Q1" />
+  );
+  expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+});
+
+test('shows the assessment name in the confirmation dialog', async () => {
+  render(
+    <DeleteAssessmentButton projectId="p1" assessmentId="a1" assessmentName="Mobile Audit Q1" />
+  );
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  expect(await screen.findByText(/mobile audit q1/i)).toBeInTheDocument();
+});
+
+test('calls the correct DELETE API endpoint on confirm', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: true }),
+  });
+
+  render(
+    <DeleteAssessmentButton projectId="p1" assessmentId="a1" assessmentName="Mobile Audit Q1" />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const confirmButton = await screen.findByRole('button', { name: /delete assessment/i });
+  fireEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/projects/p1/assessments/a1',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+});
+
+test('redirects to assessments list on success', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: true }),
+  });
+
+  render(
+    <DeleteAssessmentButton projectId="p1" assessmentId="a1" assessmentName="Mobile Audit Q1" />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const confirmButton = await screen.findByRole('button', { name: /delete assessment/i });
+  fireEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(mockPush).toHaveBeenCalledWith('/projects/p1/assessments');
+  });
+});
+
+test('shows an error toast on API failure', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: false }),
+  });
+
+  render(
+    <DeleteAssessmentButton projectId="p1" assessmentId="a1" assessmentName="Mobile Audit Q1" />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const confirmButton = await screen.findByRole('button', { name: /delete assessment/i });
+  fireEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/assessments/status-transition-button.test.tsx
+++ b/src/components/__tests__/assessments/status-transition-button.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+// Mock next/navigation
+const mockRefresh = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: mockRefresh }) }));
+// Mock fetch
+global.fetch = vi.fn();
+
+import { StatusTransitionButton } from '@/components/assessments/status-transition-button';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders "Mark as In Progress" when currentStatus is planning', () => {
+  render(<StatusTransitionButton projectId="p1" assessmentId="a1" currentStatus="planning" />);
+  expect(screen.getByRole('button', { name: /mark as in progress/i })).toBeInTheDocument();
+});
+
+test('renders "Mark as Complete" when currentStatus is in_progress', () => {
+  render(<StatusTransitionButton projectId="p1" assessmentId="a1" currentStatus="in_progress" />);
+  expect(screen.getByRole('button', { name: /mark as complete/i })).toBeInTheDocument();
+});
+
+test('renders nothing when currentStatus is completed', () => {
+  const { container } = render(
+    <StatusTransitionButton projectId="p1" assessmentId="a1" currentStatus="completed" />
+  );
+  expect(container.firstChild).toBeNull();
+});
+
+test('calls PUT endpoint and router.refresh() after a successful transition', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: true }),
+  });
+
+  render(<StatusTransitionButton projectId="p1" assessmentId="a1" currentStatus="planning" />);
+
+  fireEvent.click(screen.getByRole('button', { name: /mark as in progress/i }));
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/projects/p1/assessments/a1',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ status: 'in_progress' }),
+      })
+    );
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/src/components/assessments/assessment-card.tsx
+++ b/src/components/assessments/assessment-card.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { AssessmentWithCounts } from '@/lib/db/assessments';
+
+interface AssessmentCardProps {
+  assessment: AssessmentWithCounts;
+  projectId: string;
+}
+
+const statusConfig = {
+  planning: { label: 'Planning', className: 'bg-gray-100 text-gray-700 hover:bg-gray-100' },
+  in_progress: { label: 'In Progress', className: 'bg-blue-100 text-blue-700 hover:bg-blue-100' },
+  completed: { label: 'Completed', className: 'bg-green-100 text-green-700 hover:bg-green-100' },
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function AssessmentCard({ assessment, projectId }: AssessmentCardProps) {
+  const status = statusConfig[assessment.status];
+
+  return (
+    <Link href={`/projects/${projectId}/assessments/${assessment.id}`}>
+      <Card className="h-full hover:border-primary/50 transition-colors cursor-pointer">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="text-lg">{assessment.name}</CardTitle>
+            <Badge className={status.className}>{status.label}</Badge>
+          </div>
+          {assessment.description && (
+            <p className="text-sm text-muted-foreground line-clamp-2">{assessment.description}</p>
+          )}
+        </CardHeader>
+        <CardContent className="flex gap-4 text-sm text-muted-foreground">
+          {(assessment.test_date_start || assessment.test_date_end) && (
+            <span>
+              {formatDate(assessment.test_date_start)}
+              {assessment.test_date_end && ` – ${formatDate(assessment.test_date_end)}`}
+            </span>
+          )}
+          <span>
+            {assessment.issue_count} issue{assessment.issue_count !== 1 ? 's' : ''}
+          </span>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/assessments/assessment-form.tsx
+++ b/src/components/assessments/assessment-form.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/select';
 import type { Assessment } from '@/lib/db/assessments';
 
-interface AssessmentFormData {
+export interface AssessmentFormData {
   name: string;
   description: string;
   test_date_start: string;

--- a/src/components/assessments/assessment-form.tsx
+++ b/src/components/assessments/assessment-form.tsx
@@ -1,0 +1,120 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { Assessment } from '@/lib/db/assessments';
+
+interface AssessmentFormData {
+  name: string;
+  description: string;
+  test_date_start: string;
+  test_date_end: string;
+  status: 'planning' | 'in_progress' | 'completed';
+}
+
+interface AssessmentFormProps {
+  assessment?: Assessment;
+  onSubmit: (data: AssessmentFormData) => void;
+  loading?: boolean;
+}
+
+function toDateInputValue(iso: string | null | undefined): string {
+  if (!iso) return '';
+  // ISO datetime string → date string (YYYY-MM-DD)
+  return iso.slice(0, 10);
+}
+
+export function AssessmentForm({ assessment, onSubmit, loading }: AssessmentFormProps) {
+  const [name, setName] = useState(assessment?.name ?? '');
+  const [description, setDescription] = useState(assessment?.description ?? '');
+  const [testDateStart, setTestDateStart] = useState(toDateInputValue(assessment?.test_date_start));
+  const [testDateEnd, setTestDateEnd] = useState(toDateInputValue(assessment?.test_date_end));
+  const [status, setStatus] = useState<'planning' | 'in_progress' | 'completed'>(
+    assessment?.status ?? 'planning'
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      name,
+      description,
+      test_date_start: testDateStart,
+      test_date_end: testDateEnd,
+      status,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-2xl">
+      <div className="space-y-1.5">
+        <Label htmlFor="name">Name *</Label>
+        <Input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          placeholder="e.g. Mobile App Q1 Audit"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="description">Description</Label>
+        <Textarea
+          id="description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          placeholder="Brief description of this assessment"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="test_date_start">Start Date</Label>
+          <Input
+            id="test_date_start"
+            type="date"
+            value={testDateStart}
+            onChange={(e) => setTestDateStart(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="test_date_end">End Date</Label>
+          <Input
+            id="test_date_end"
+            type="date"
+            value={testDateEnd}
+            onChange={(e) => setTestDateEnd(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="status">Status</Label>
+        <Select value={status} onValueChange={(v) => setStatus(v as typeof status)}>
+          <SelectTrigger id="status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="planning">Planning</SelectItem>
+            <SelectItem value="in_progress">In Progress</SelectItem>
+            <SelectItem value="completed">Completed</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Button type="submit" disabled={loading}>
+        {loading ? 'Saving…' : 'Save Assessment'}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/assessments/delete-assessment-button.tsx
+++ b/src/components/assessments/delete-assessment-button.tsx
@@ -1,0 +1,77 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteAssessmentButtonProps {
+  projectId: string;
+  assessmentId: string;
+  assessmentName: string;
+}
+
+export function DeleteAssessmentButton({
+  projectId,
+  assessmentId,
+  assessmentName,
+}: DeleteAssessmentButtonProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleDelete = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/assessments/${assessmentId}`, {
+        method: 'DELETE',
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success('Assessment deleted');
+      router.push(`/projects/${projectId}/assessments`);
+    } catch {
+      toast.error('Failed to delete assessment');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" disabled={loading}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {assessmentName}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete the assessment and all its issues. This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Delete Assessment
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/assessments/status-transition-button.tsx
+++ b/src/components/assessments/status-transition-button.tsx
@@ -37,7 +37,7 @@ export function StatusTransitionButton({
       });
       const json = await res.json();
       if (!json.success) throw new Error(json.error);
-      toast.success(`Assessment marked as ${transition.status.replace('_', ' ')}`);
+      toast.success(`Assessment marked as ${transition.status.replaceAll('_', ' ')}`);
       router.refresh();
     } catch {
       toast.error('Failed to update status');

--- a/src/components/assessments/status-transition-button.tsx
+++ b/src/components/assessments/status-transition-button.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+
+interface StatusTransitionButtonProps {
+  projectId: string;
+  assessmentId: string;
+  currentStatus: 'planning' | 'in_progress' | 'completed';
+}
+
+const nextStatus: Record<string, { status: string; label: string } | null> = {
+  planning: { status: 'in_progress', label: 'Mark as In Progress' },
+  in_progress: { status: 'completed', label: 'Mark as Complete' },
+  completed: null,
+};
+
+export function StatusTransitionButton({
+  projectId,
+  assessmentId,
+  currentStatus,
+}: StatusTransitionButtonProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const transition = nextStatus[currentStatus];
+
+  if (!transition) return null;
+
+  const handleTransition = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/assessments/${assessmentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: transition.status }),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success(`Assessment marked as ${transition.status.replace('_', ' ')}`);
+      router.refresh();
+    } catch {
+      toast.error('Failed to update status');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button variant="outline" onClick={handleTransition} disabled={loading}>
+      {transition.label}
+    </Button>
+  );
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };


### PR DESCRIPTION
## Summary
- Assessments list/detail/create/edit pages under `/projects/:id/assessments`
- `AssessmentCard` with date range and status badge
- `StatusTransitionButton` for open → in-progress → closed workflow
- `DeleteAssessmentButton` with `AlertDialog` confirmation

## Test Plan
- [ ] Unit tests: 44 files, 443 tests passing
- [ ] Lint, type-check, format all clean
- [ ] Create assessment → transition status → delete through UI