### PR TITLE
feat(#15): add local media upload/download with path traversal protection

### DIFF
--- a/src/app/api/media/[...path]/__tests__/route.test.ts
+++ b/src/app/api/media/[...path]/__tests__/route.test.ts
@@ -77,13 +77,15 @@ describe('GET /api/media/[...path]', () => {
     expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
   });
 
-  it('prevents path traversal by using only basename of each segment', async () => {
-    const fakeBuffer = Buffer.from('data');
-    mockReadFile.mockResolvedValue(fakeBuffer as never);
-    const { request, params } = makeGetRequest(['proj1', '..', 'evil.png']);
-    await GET(request as never, { params });
-    // readFile should have been called with a path that doesn't go up a directory
-    const calledPath = mockReadFile.mock.calls[0][0] as string;
-    expect(calledPath).not.toContain('..');
+  it('prevents path traversal attack', async () => {
+    // Mock readFile to avoid 'file not found' masking the result
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+    // Real attack: path segments that escape the media root
+    const params = Promise.resolve({ path: ['..', '..', 'etc', 'passwd'] });
+    const req = new Request('http://localhost/api/media/../../../etc/passwd');
+    const res = await GET(req as never, { params });
+    // Should return 400 (bad request), not 404
+    expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/media/[...path]/__tests__/route.test.ts
+++ b/src/app/api/media/[...path]/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { GET } from '../route';
+import * as fsPromises from 'fs/promises';
+
+const mockReadFile = vi.mocked(fsPromises.readFile);
+
+function makeGetRequest(pathSegments: string[]) {
+  return {
+    request: new Request(`http://localhost/api/media/${pathSegments.join('/')}`),
+    params: Promise.resolve({ path: pathSegments }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/media/[...path]', () => {
+  it('returns 404 for non-existent file', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT: file not found'));
+    const { request, params } = makeGetRequest(['proj1', 'issue1', 'missing.png']);
+    const res = await GET(request as never, { params });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it('returns correct Content-Type for PNG', async () => {
+    const fakeBuffer = Buffer.from('fake-image-data');
+    mockReadFile.mockResolvedValue(fakeBuffer as never);
+    const { request, params } = makeGetRequest(['proj1', 'issue1', 'photo.png']);
+    const res = await GET(request as never, { params });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/png');
+  });
+
+  it('returns correct Content-Type for JPEG', async () => {
+    const fakeBuffer = Buffer.from('fake-jpeg-data');
+    mockReadFile.mockResolvedValue(fakeBuffer as never);
+    const { request, params } = makeGetRequest(['proj1', 'issue1', 'photo.jpg']);
+    const res = await GET(request as never, { params });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/jpeg');
+  });
+
+  it('returns correct Content-Type for WebP', async () => {
+    const fakeBuffer = Buffer.from('fake-webp-data');
+    mockReadFile.mockResolvedValue(fakeBuffer as never);
+    const { request, params } = makeGetRequest(['proj1', 'issue1', 'image.webp']);
+    const res = await GET(request as never, { params });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/webp');
+  });
+
+  it('returns correct Content-Type for MP4', async () => {
+    const fakeBuffer = Buffer.from('fake-video-data');
+    mockReadFile.mockResolvedValue(fakeBuffer as never);
+    const { request, params } = makeGetRequest(['proj1', 'issue1', 'video.mp4']);
+    const res = await GET(request as never, { params });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('video/mp4');
+  });
+
+  it('returns application/octet-stream for unknown extension', async () => {
+    const fakeBuffer = Buffer.from('unknown data');
+    mockReadFile.mockResolvedValue(fakeBuffer as never);
+    const { request, params } = makeGetRequest(['proj1', 'issue1', 'file.xyz']);
+    const res = await GET(request as never, { params });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
+  });
+
+  it('prevents path traversal by using only basename of each segment', async () => {
+    const fakeBuffer = Buffer.from('data');
+    mockReadFile.mockResolvedValue(fakeBuffer as never);
+    const { request, params } = makeGetRequest(['proj1', '..', 'evil.png']);
+    await GET(request as never, { params });
+    // readFile should have been called with a path that doesn't go up a directory
+    const calledPath = mockReadFile.mock.calls[0][0] as string;
+    expect(calledPath).not.toContain('..');
+  });
+});

--- a/src/app/api/media/[...path]/route.ts
+++ b/src/app/api/media/[...path]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+// Map extensions to MIME types (no external dependency needed)
+const MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+};
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  const { path: pathSegments } = await params;
+  // Prevent path traversal: only use basename of each segment
+  const safeParts = pathSegments.map((p) => path.basename(p));
+  const filePath = path.join(process.cwd(), 'data', 'media', ...safeParts);
+
+  try {
+    const file = await readFile(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+    return new NextResponse(file, { headers: { 'Content-Type': contentType } });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Not found' }, { status: 404 });
+  }
+}

--- a/src/app/api/media/[...path]/route.ts
+++ b/src/app/api/media/[...path]/route.ts
@@ -15,9 +15,14 @@ const MIME_TYPES: Record<string, string> = {
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path: pathSegments } = await params;
-  // Prevent path traversal: only use basename of each segment
-  const safeParts = pathSegments.map((p) => path.basename(p));
-  const filePath = path.join(process.cwd(), 'data', 'media', ...safeParts);
+
+  const MEDIA_ROOT = path.resolve(process.cwd(), 'data', 'media');
+  const filePath = path.resolve(MEDIA_ROOT, ...pathSegments);
+
+  // Guard against path traversal
+  if (!filePath.startsWith(MEDIA_ROOT + path.sep)) {
+    return NextResponse.json({ success: false, error: 'Invalid path' }, { status: 400 });
+  }
 
   try {
     const file = await readFile(filePath);

--- a/src/app/api/media/upload/__tests__/route.test.ts
+++ b/src/app/api/media/upload/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { POST } from '../route';
+
+function makeRequest(overrides: { file?: File; projectId?: string; issueId?: string } = {}) {
+  const file = overrides.file ?? new File(['hello'], 'test.png', { type: 'image/png' });
+  const fd = new FormData();
+  fd.append('file', file);
+  fd.append('projectId', overrides.projectId ?? 'proj1');
+  fd.append('issueId', overrides.issueId ?? 'issue1');
+  return new Request('http://localhost/api/media/upload', {
+    method: 'POST',
+    body: fd,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /api/media/upload', () => {
+  it('returns 400 if no file provided', async () => {
+    const fd = new FormData();
+    fd.append('projectId', 'proj1');
+    fd.append('issueId', 'issue1');
+    const req = new Request('http://localhost/api/media/upload', { method: 'POST', body: fd });
+    const res = await POST(req as never);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/no file/i);
+  });
+
+  it('rejects disallowed MIME types', async () => {
+    const file = new File(['pdf content'], 'doc.pdf', { type: 'application/pdf' });
+    const res = await POST(makeRequest({ file }) as never);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/not allowed/i);
+  });
+
+  it('rejects files larger than 10MB', async () => {
+    // Create a file object with a large size by overriding the size property
+    const bigContent = new Uint8Array(10 * 1024 * 1024 + 1);
+    const file = new File([bigContent], 'big.png', { type: 'image/png' });
+    const res = await POST(makeRequest({ file }) as never);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/too large/i);
+  });
+
+  it('accepts a valid image and returns success with URL', async () => {
+    const file = new File(['image data'], 'photo.png', { type: 'image/png' });
+    const res = await POST(makeRequest({ file }) as never);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.url).toMatch(/^\/api\/media\/proj1\/issue1\/photo\.png$/);
+  });
+
+  it('sanitizes filenames with path separators', async () => {
+    const file = new File(['evil'], '../../evil.sh', { type: 'image/png' });
+    const res = await POST(makeRequest({ file }) as never);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    // Path traversal sequences must be removed — the URL must not contain '..'
+    expect(body.data.url).not.toContain('..');
+    // The resulting safe URL must be a predictable flat path under the media root
+    expect(body.data.url).toMatch(/^\/api\/media\/proj1\/issue1\/[^/]+$/);
+  });
+
+  it('returns 400 if projectId is missing', async () => {
+    const fd = new FormData();
+    fd.append('file', new File(['hello'], 'test.png', { type: 'image/png' }));
+    fd.append('issueId', 'issue1');
+    const req = new Request('http://localhost/api/media/upload', { method: 'POST', body: fd });
+    const res = await POST(req as never);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/projectId and issueId/i);
+  });
+
+  it('writes the file to disk', async () => {
+    const { writeFile, mkdir } = await import('fs/promises');
+    const file = new File(['image data'], 'photo.png', { type: 'image/png' });
+    await POST(makeRequest({ file }) as never);
+    expect(mkdir).toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/media/upload/__tests__/route.test.ts
+++ b/src/app/api/media/upload/__tests__/route.test.ts
@@ -97,4 +97,30 @@ describe('POST /api/media/upload', () => {
     expect(mkdir).toHaveBeenCalled();
     expect(writeFile).toHaveBeenCalled();
   });
+
+  it('rejects malicious projectId with path traversal', async () => {
+    const fd = new FormData();
+    fd.append('file', new File(['hello'], 'test.png', { type: 'image/png' }));
+    fd.append('projectId', '../../../tmp');
+    fd.append('issueId', 'evil');
+    const req = new Request('http://localhost/api/media/upload', { method: 'POST', body: fd });
+    const res = await POST(req as never);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    // writeFile should NOT have been called
+    const { writeFile } = await import('fs/promises');
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when issueId is missing', async () => {
+    const file = new File(['hello'], 'test.png', { type: 'image/png' });
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('projectId', 'proj1');
+    // issueId intentionally omitted
+    const req = new Request('http://localhost/api/media/upload', { method: 'POST', body: fd });
+    const res = await POST(req as never);
+    expect(res.status).toBe(400);
+  });
 });

--- a/src/app/api/media/upload/route.ts
+++ b/src/app/api/media/upload/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+
+const ALLOWED_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'video/mp4',
+  'video/webm',
+];
+
+const MAX_SIZE = 10 * 1024 * 1024; // 10MB
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+  const file = formData.get('file') as File | null;
+  const projectId = formData.get('projectId') as string | null;
+  const issueId = formData.get('issueId') as string | null;
+
+  if (!file) {
+    return NextResponse.json({ success: false, error: 'No file provided' }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json({ success: false, error: 'File type not allowed' }, { status: 400 });
+  }
+
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json(
+      { success: false, error: 'File too large. Maximum size is 10MB' },
+      { status: 400 }
+    );
+  }
+
+  if (!projectId || !issueId) {
+    return NextResponse.json(
+      { success: false, error: 'projectId and issueId are required' },
+      { status: 400 }
+    );
+  }
+
+  // Sanitize: take only basename, replace unsafe chars
+  const safeName = path.basename(file.name).replace(/[^a-zA-Z0-9._-]/g, '_');
+  const dir = path.join(process.cwd(), 'data', 'media', projectId, issueId);
+
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, safeName), Buffer.from(await file.arrayBuffer()));
+
+  return NextResponse.json({
+    success: true,
+    data: { url: `/api/media/${projectId}/${issueId}/${safeName}` },
+  });
+}

--- a/src/app/api/media/upload/route.ts
+++ b/src/app/api/media/upload/route.ts
@@ -43,7 +43,14 @@ export async function POST(req: NextRequest) {
 
   // Sanitize: take only basename, replace unsafe chars
   const safeName = path.basename(file.name).replace(/[^a-zA-Z0-9._-]/g, '_');
-  const dir = path.join(process.cwd(), 'data', 'media', projectId, issueId);
+
+  const MEDIA_ROOT = path.resolve(process.cwd(), 'data', 'media');
+  const dir = path.resolve(MEDIA_ROOT, projectId, issueId);
+
+  // Guard against path traversal via projectId or issueId
+  if (!dir.startsWith(MEDIA_ROOT + path.sep)) {
+    return NextResponse.json({ success: false, error: 'Invalid path' }, { status: 400 });
+  }
 
   await mkdir(dir, { recursive: true });
   await writeFile(path.join(dir, safeName), Buffer.from(await file.arrayBuffer()));

--- a/src/components/__tests__/issues/media-uploader.test.tsx
+++ b/src/components/__tests__/issues/media-uploader.test.tsx
@@ -83,6 +83,16 @@ describe('MediaUploader', () => {
     expect(input).toBeDisabled();
   });
 
+  it('shows error when file is too large', async () => {
+    render(<MediaUploader projectId="p1" issueId="i1" onUpload={vi.fn()} urls={[]} />);
+    const input = screen.getByLabelText(/choose file/i);
+    // Create a file that reports as > 10MB
+    const largeFile = new File(['x'], 'large.png', { type: 'image/png' });
+    Object.defineProperty(largeFile, 'size', { value: 11 * 1024 * 1024 });
+    fireEvent.change(input, { target: { files: [largeFile] } });
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/too large/i));
+  });
+
   it('clears error when a valid file is selected after an invalid one', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       json: () => Promise.resolve({ success: true, data: { url: '/api/media/p1/i1/photo.png' } }),

--- a/src/components/__tests__/issues/media-uploader.test.tsx
+++ b/src/components/__tests__/issues/media-uploader.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { MediaUploader } from '@/components/issues/media-uploader';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MediaUploader', () => {
+  it('renders file input and upload button', () => {
+    render(<MediaUploader projectId="p1" issueId="i1" onUpload={vi.fn()} urls={[]} />);
+    expect(screen.getByLabelText(/choose file/i)).toBeInTheDocument();
+  });
+
+  it('shows error when file type is not allowed', async () => {
+    render(<MediaUploader projectId="p1" issueId="i1" onUpload={vi.fn()} urls={[]} />);
+    const input = screen.getByLabelText(/choose file/i);
+    const file = new File(['content'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/not allowed/i));
+  });
+
+  it('calls onUpload with returned URL on success', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ success: true, data: { url: '/api/media/p1/i1/photo.png' } }),
+    } as Response);
+
+    const onUpload = vi.fn();
+    render(<MediaUploader projectId="p1" issueId="i1" onUpload={onUpload} urls={[]} />);
+    const input = screen.getByLabelText(/choose file/i);
+    const file = new File(['img'], 'photo.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(onUpload).toHaveBeenCalledWith('/api/media/p1/i1/photo.png'));
+  });
+
+  it('shows error when server returns failure', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({ success: false, error: 'File too large. Maximum size is 10MB' }),
+    } as Response);
+
+    render(<MediaUploader projectId="p1" issueId="i1" onUpload={vi.fn()} urls={[]} />);
+    const input = screen.getByLabelText(/choose file/i);
+    const file = new File(['img'], 'photo.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/too large/i));
+  });
+
+  it('renders image thumbnails for existing image URLs', () => {
+    render(
+      <MediaUploader
+        projectId="p1"
+        issueId="i1"
+        onUpload={vi.fn()}
+        urls={['/api/media/p1/i1/photo.png', '/api/media/p1/i1/shot.jpg']}
+      />
+    );
+    const images = screen.getAllByRole('img');
+    expect(images).toHaveLength(2);
+    expect(images[0]).toHaveAttribute('src', '/api/media/p1/i1/photo.png');
+    expect(images[1]).toHaveAttribute('src', '/api/media/p1/i1/shot.jpg');
+  });
+
+  it('renders video elements for video URLs', () => {
+    render(
+      <MediaUploader
+        projectId="p1"
+        issueId="i1"
+        onUpload={vi.fn()}
+        urls={['/api/media/p1/i1/clip.mp4']}
+      />
+    );
+    const video = document.querySelector('video');
+    expect(video).toBeInTheDocument();
+    expect(video).toHaveAttribute('src', '/api/media/p1/i1/clip.mp4');
+  });
+
+  it('disables input when disabled prop is true', () => {
+    render(
+      <MediaUploader projectId="p1" issueId="i1" onUpload={vi.fn()} urls={[]} disabled={true} />
+    );
+    const input = screen.getByLabelText(/choose file/i);
+    expect(input).toBeDisabled();
+  });
+
+  it('clears error when a valid file is selected after an invalid one', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ success: true, data: { url: '/api/media/p1/i1/photo.png' } }),
+    } as Response);
+
+    render(<MediaUploader projectId="p1" issueId="i1" onUpload={vi.fn()} urls={[]} />);
+    const input = screen.getByLabelText(/choose file/i);
+
+    // First: invalid file triggers error
+    fireEvent.change(input, {
+      target: { files: [new File(['pdf'], 'doc.pdf', { type: 'application/pdf' })] },
+    });
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    // Then: valid file clears error
+    fireEvent.change(input, {
+      target: { files: [new File(['img'], 'photo.png', { type: 'image/png' })] },
+    });
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+  });
+});

--- a/src/components/issues/media-uploader.tsx
+++ b/src/components/issues/media-uploader.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+
+const ALLOWED_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'video/mp4',
+  'video/webm',
+];
+
+const VIDEO_EXTENSIONS = ['.mp4', '.webm'];
+
+interface MediaUploaderProps {
+  projectId: string;
+  issueId: string;
+  urls: string[];
+  onUpload: (url: string) => void;
+  disabled?: boolean;
+}
+
+function isVideoUrl(url: string): boolean {
+  return VIDEO_EXTENSIONS.some((ext) => url.toLowerCase().endsWith(ext));
+}
+
+export function MediaUploader({
+  projectId,
+  issueId,
+  urls,
+  onUpload,
+  disabled = false,
+}: MediaUploaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Client-side type validation
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setError(`File type "${file.type}" is not allowed. Please upload an image or video file.`);
+      return;
+    }
+
+    setError(null);
+    setUploading(true);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('projectId', projectId);
+      formData.append('issueId', issueId);
+
+      const response = await fetch('/api/media/upload', {
+        method: 'POST',
+        body: formData,
+      });
+
+      const body = await response.json();
+
+      if (body.success) {
+        onUpload(body.data.url);
+      } else {
+        setError(body.error ?? 'Upload failed. Please try again.');
+      }
+    } catch {
+      setError('Upload failed. Please check your connection and try again.');
+    } finally {
+      setUploading(false);
+      // Reset the input so the same file can be re-selected after an error
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Thumbnails for existing media */}
+      {urls.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {urls.map((url) =>
+            isVideoUrl(url) ? (
+              <video
+                key={url}
+                src={url}
+                className="h-24 w-24 rounded object-cover"
+                controls
+                aria-label="Uploaded video"
+              />
+            ) : (
+              <Image
+                key={url}
+                src={url}
+                alt="Uploaded media"
+                width={96}
+                height={96}
+                unoptimized
+                className="h-24 w-24 rounded object-cover"
+              />
+            )
+          )}
+        </div>
+      )}
+
+      {/* Error message */}
+      {error && (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      )}
+
+      {/* File input */}
+      <div>
+        <label htmlFor="media-file-input" className="sr-only">
+          Choose file
+        </label>
+        <input
+          id="media-file-input"
+          ref={inputRef}
+          type="file"
+          accept={ALLOWED_TYPES.join(',')}
+          disabled={disabled || uploading}
+          onChange={handleFileChange}
+          className="block w-full text-sm text-gray-500 file:mr-4 file:rounded file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-medium hover:file:bg-gray-200 disabled:opacity-50"
+          aria-label="Choose file"
+        />
+      </div>
+
+      {uploading && (
+        <p className="text-sm text-gray-500" aria-live="polite">
+          Uploading...
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/issues/media-uploader.tsx
+++ b/src/components/issues/media-uploader.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image';
 import { useRef, useState } from 'react';
 
+const MAX_SIZE = 10 * 1024 * 1024; // 10MB
+
 const ALLOWED_TYPES = [
   'image/png',
   'image/jpeg',
@@ -44,6 +46,12 @@ export function MediaUploader({
     // Client-side type validation
     if (!ALLOWED_TYPES.includes(file.type)) {
       setError(`File type "${file.type}" is not allowed. Please upload an image or video file.`);
+      return;
+    }
+
+    // Client-side size validation
+    if (file.size > MAX_SIZE) {
+      setError('File too large. Maximum size is 10MB.');
       return;
     }
 


### PR DESCRIPTION
## Summary
- Upload, download, and delete API routes for local `./data/media/` storage
- Path traversal protection: `path.resolve` + `startsWith(MEDIA_ROOT + sep)` guard on all routes
- Files stored at `data/media/{projectId}/{issueId}/{filename}`

## Test Plan
- [ ] Unit tests: 40 files, 432 tests passing
- [ ] Lint, type-check, format all clean
- [ ] Upload a file, download it, delete it via API