### PR TITLE
feat(#16): add reports UI with publish/unpublish flow

### DIFF
--- a/src/app/(app)/reports/[id]/edit/page.tsx
+++ b/src/app/(app)/reports/[id]/edit/page.tsx
@@ -32,7 +32,7 @@ export default async function EditReportPage({ params }: PageProps) {
 
       <h1 className="text-2xl font-bold mb-6">Edit Report</h1>
 
-      <ReportForm report={report} projects={[]} />
+      <ReportForm report={report} />
     </div>
   );
 }

--- a/src/app/(app)/reports/[id]/edit/page.tsx
+++ b/src/app/(app)/reports/[id]/edit/page.tsx
@@ -1,0 +1,38 @@
+export const dynamic = 'force-dynamic';
+
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import { getReport } from '@/lib/db/reports';
+import { ReportForm } from '@/components/reports/report-form';
+
+type PageProps = { params: Promise<{ id: string }> };
+
+export default async function EditReportPage({ params }: PageProps) {
+  const { id } = await params;
+  const report = getReport(id);
+
+  if (!report) {
+    notFound();
+  }
+
+  if (report.status === 'published') {
+    notFound();
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/reports/${id}`}
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ChevronLeft className="h-4 w-4 mr-1" />
+        Back to Report
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">Edit Report</h1>
+
+      <ReportForm report={report} projects={[]} />
+    </div>
+  );
+}

--- a/src/app/(app)/reports/[id]/page.tsx
+++ b/src/app/(app)/reports/[id]/page.tsx
@@ -1,0 +1,144 @@
+export const dynamic = 'force-dynamic';
+
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { ChevronLeft, Pencil } from 'lucide-react';
+import { getReport } from '@/lib/db/reports';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { DeleteReportButton } from '@/components/reports/delete-report-button';
+import { PublishReportButton } from '@/components/reports/publish-report-button';
+
+function getTypeBadgeClass(type: string): string {
+  switch (type) {
+    case 'executive':
+      return 'bg-blue-100 text-blue-800 border-blue-200';
+    case 'detailed':
+      return 'bg-purple-100 text-purple-800 border-purple-200';
+    default:
+      return 'bg-gray-100 text-gray-800 border-gray-200';
+  }
+}
+
+function getStatusBadgeClass(status: string): string {
+  return status === 'published'
+    ? 'bg-green-100 text-green-800 border-green-200'
+    : 'bg-yellow-100 text-yellow-800 border-yellow-200';
+}
+
+type PageProps = { params: Promise<{ id: string }> };
+
+export default async function ReportDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const report = getReport(id);
+
+  if (!report) {
+    notFound();
+  }
+
+  // content is stored as JSON: [{title, body}]
+  let sections: { title: string; body: string }[] = [];
+  try {
+    sections = JSON.parse(report.content) as { title: string; body: string }[];
+  } catch {
+    sections = [];
+  }
+
+  const isPublished = report.status === 'published';
+
+  return (
+    <div>
+      {/* Back link */}
+      <Link
+        href="/reports"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ChevronLeft className="h-4 w-4 mr-1" />
+        Back to Reports
+      </Link>
+
+      <div className="flex flex-col gap-6 lg:flex-row">
+        {/* Main content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-4 mb-4">
+            <h1 className="text-2xl font-bold">{report.title}</h1>
+            <div className="flex items-center gap-2 shrink-0">
+              {!isPublished && (
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/reports/${report.id}/edit`}>
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Edit
+                  </Link>
+                </Button>
+              )}
+              <PublishReportButton reportId={report.id} isPublished={isPublished} />
+              <DeleteReportButton reportId={report.id} reportTitle={report.title} />
+            </div>
+          </div>
+
+          <Separator className="mb-6" />
+
+          {sections.length === 0 ? (
+            <p className="text-muted-foreground italic">
+              No sections yet. Edit this report to add content.
+            </p>
+          ) : (
+            <div className="space-y-8">
+              {sections.map((section, i) => (
+                <div key={i}>
+                  <h2 className="text-xl font-semibold mb-3">{section.title}</h2>
+                  <p className="whitespace-pre-wrap text-sm leading-relaxed">{section.body}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <aside className="lg:w-64 shrink-0">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Report Info
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Type</span>
+                <Badge className={getTypeBadgeClass(report.type)} variant="outline">
+                  {report.type}
+                </Badge>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Status</span>
+                <Badge className={getStatusBadgeClass(report.status)} variant="outline">
+                  {report.status}
+                </Badge>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Sections</span>
+                <span>{sections.length}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Created</span>
+                <span>{new Date(report.created_at).toLocaleDateString()}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Updated</span>
+                <span>{new Date(report.updated_at).toLocaleDateString()}</span>
+              </div>
+              {report.published_at && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Published</span>
+                  <span>{new Date(report.published_at).toLocaleDateString()}</span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/reports/[id]/page.tsx
+++ b/src/app/(app)/reports/[id]/page.tsx
@@ -4,29 +4,14 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { ChevronLeft, Pencil } from 'lucide-react';
 import { getReport } from '@/lib/db/reports';
+import type { ReportSection } from '@/lib/db/reports';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { DeleteReportButton } from '@/components/reports/delete-report-button';
 import { PublishReportButton } from '@/components/reports/publish-report-button';
-
-function getTypeBadgeClass(type: string): string {
-  switch (type) {
-    case 'executive':
-      return 'bg-blue-100 text-blue-800 border-blue-200';
-    case 'detailed':
-      return 'bg-purple-100 text-purple-800 border-purple-200';
-    default:
-      return 'bg-gray-100 text-gray-800 border-gray-200';
-  }
-}
-
-function getStatusBadgeClass(status: string): string {
-  return status === 'published'
-    ? 'bg-green-100 text-green-800 border-green-200'
-    : 'bg-yellow-100 text-yellow-800 border-yellow-200';
-}
+import { getTypeBadgeClass, getStatusBadgeClass } from '@/components/reports/report-badge-utils';
 
 type PageProps = { params: Promise<{ id: string }> };
 
@@ -39,9 +24,15 @@ export default async function ReportDetailPage({ params }: PageProps) {
   }
 
   // content is stored as JSON: [{title, body}]
-  let sections: { title: string; body: string }[] = [];
+  // Filter out any entries missing required fields to avoid silent empty renders
+  let sections: ReportSection[] = [];
   try {
-    sections = JSON.parse(report.content) as { title: string; body: string }[];
+    const raw = JSON.parse(report.content);
+    sections = Array.isArray(raw)
+      ? raw.filter(
+          (s): s is ReportSection => typeof s?.title === 'string' && typeof s?.body === 'string'
+        )
+      : [];
   } catch {
     sections = [];
   }

--- a/src/app/(app)/reports/new/page.tsx
+++ b/src/app/(app)/reports/new/page.tsx
@@ -1,0 +1,38 @@
+export const dynamic = 'force-dynamic';
+
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import { getProjects } from '@/lib/db/projects';
+import { ReportForm } from '@/components/reports/report-form';
+
+export default function NewReportPage() {
+  const projects = getProjects().map((p) => ({ id: p.id, name: p.name }));
+
+  return (
+    <div>
+      <Link
+        href="/reports"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ChevronLeft className="h-4 w-4 mr-1" />
+        Back to Reports
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">New Report</h1>
+
+      {projects.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <h2 className="text-lg font-semibold mb-2">No projects found</h2>
+          <p className="text-muted-foreground mb-4">
+            You need at least one project before creating a report.
+          </p>
+          <Link href="/projects/new" className="text-primary hover:underline">
+            Create a project
+          </Link>
+        </div>
+      ) : (
+        <ReportForm projects={projects} />
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -12,23 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-
-function getTypeBadgeClass(type: string): string {
-  switch (type) {
-    case 'executive':
-      return 'bg-blue-100 text-blue-800 border-blue-200';
-    case 'detailed':
-      return 'bg-purple-100 text-purple-800 border-purple-200';
-    default:
-      return 'bg-gray-100 text-gray-800 border-gray-200';
-  }
-}
-
-function getStatusBadgeClass(status: string): string {
-  return status === 'published'
-    ? 'bg-green-100 text-green-800 border-green-200'
-    : 'bg-yellow-100 text-yellow-800 border-yellow-200';
-}
+import { getTypeBadgeClass, getStatusBadgeClass } from '@/components/reports/report-badge-utils';
 
 export default function ReportsPage() {
   const reports = getReports();

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -1,0 +1,95 @@
+export const dynamic = 'force-dynamic';
+
+import Link from 'next/link';
+import { getReports } from '@/lib/db/reports';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+function getTypeBadgeClass(type: string): string {
+  switch (type) {
+    case 'executive':
+      return 'bg-blue-100 text-blue-800 border-blue-200';
+    case 'detailed':
+      return 'bg-purple-100 text-purple-800 border-purple-200';
+    default:
+      return 'bg-gray-100 text-gray-800 border-gray-200';
+  }
+}
+
+function getStatusBadgeClass(status: string): string {
+  return status === 'published'
+    ? 'bg-green-100 text-green-800 border-green-200'
+    : 'bg-yellow-100 text-yellow-800 border-yellow-200';
+}
+
+export default function ReportsPage() {
+  const reports = getReports();
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Reports</h1>
+        <Button asChild>
+          <Link href="/reports/new">New Report</Link>
+        </Button>
+      </div>
+
+      {reports.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <h2 className="text-lg font-semibold mb-2">No reports yet</h2>
+          <p className="text-muted-foreground mb-4">
+            Create your first accessibility report to document findings and share with stakeholders.
+          </p>
+          <Button asChild>
+            <Link href="/reports/new">Create Report</Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Title</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Updated</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {reports.map((report) => (
+                <TableRow key={report.id}>
+                  <TableCell>
+                    <Link href={`/reports/${report.id}`} className="font-medium hover:underline">
+                      {report.title}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={getTypeBadgeClass(report.type)} variant="outline">
+                      {report.type}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={getStatusBadgeClass(report.status)} variant="outline">
+                      {report.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {new Date(report.updated_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/reports/[id]/publish/__tests__/route.test.ts
+++ b/src/app/api/reports/[id]/publish/__tests__/route.test.ts
@@ -2,8 +2,8 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { initDb, closeDb, getDb } from '@/lib/db/index';
 import { createProject } from '@/lib/db/projects';
-import { createReport } from '@/lib/db/reports';
-import { POST } from '../route';
+import { createReport, publishReport } from '@/lib/db/reports';
+import { POST, DELETE } from '../route';
 
 let projectId: string;
 let reportId: string;
@@ -71,5 +71,42 @@ describe('POST /api/reports/[id]/publish', () => {
     const secondBody = await second.json();
     expect(secondBody.data.status).toBe('published');
     expect(secondBody.data.published_at).toBe(firstPublishedAt);
+  });
+});
+
+describe('DELETE /api/reports/[id]/publish', () => {
+  it('unpublishes a published report and reverts it to draft', async () => {
+    publishReport(reportId);
+    const response = await DELETE(
+      new Request(`http://localhost/api/reports/${reportId}/publish`, { method: 'DELETE' }),
+      makeContext(reportId)
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe('draft');
+    expect(body.data.published_at).toBeNull();
+  });
+
+  it('is idempotent — unpublishing a draft report returns 200', async () => {
+    const response = await DELETE(
+      new Request(`http://localhost/api/reports/${reportId}/publish`, { method: 'DELETE' }),
+      makeContext(reportId)
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe('draft');
+  });
+
+  it('returns 404 when report does not exist', async () => {
+    const response = await DELETE(
+      new Request('http://localhost/api/reports/no-report/publish', { method: 'DELETE' }),
+      makeContext('no-report')
+    );
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('NOT_FOUND');
   });
 });

--- a/src/app/api/reports/[id]/publish/route.ts
+++ b/src/app/api/reports/[id]/publish/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getReport, publishReport } from '@/lib/db/reports';
+import { getReport, publishReport, unpublishReport } from '@/lib/db/reports';
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -26,6 +26,34 @@ export async function POST(_request: Request, { params }: RouteContext) {
   } catch {
     return NextResponse.json(
       { success: false, error: 'Failed to publish report', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+
+  try {
+    const existing = getReport(id);
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    const unpublished = unpublishReport(id);
+    if (!unpublished) {
+      return NextResponse.json(
+        { success: false, error: 'Failed to unpublish report', code: 'INTERNAL_ERROR' },
+        { status: 500 }
+      );
+    }
+    return NextResponse.json({ success: true, data: unpublished });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to unpublish report', code: 'INTERNAL_ERROR' },
       { status: 500 }
     );
   }

--- a/src/components/__tests__/reports/publish-report-button.test.tsx
+++ b/src/components/__tests__/reports/publish-report-button.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, beforeEach } from 'vitest';
+import { PublishReportButton } from '@/components/reports/publish-report-button';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('shows Publish button when not published', () => {
+  render(<PublishReportButton reportId="r1" isPublished={false} />);
+  expect(screen.getByRole('button', { name: /publish/i })).toBeInTheDocument();
+});
+
+test('shows Unpublish button when published', () => {
+  render(<PublishReportButton reportId="r1" isPublished={true} />);
+  expect(screen.getByRole('button', { name: /unpublish/i })).toBeInTheDocument();
+});
+
+test('clicking Publish opens confirmation dialog', () => {
+  render(<PublishReportButton reportId="r1" isPublished={false} />);
+  fireEvent.click(screen.getByRole('button', { name: /^publish$/i }));
+  expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  expect(screen.getByText(/once published.*cannot be edited/i)).toBeInTheDocument();
+});
+
+test('confirmation dialog has Cancel and Publish action buttons', () => {
+  render(<PublishReportButton reportId="r1" isPublished={false} />);
+  fireEvent.click(screen.getByRole('button', { name: /^publish$/i }));
+  expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /^publish$/i })).toBeInTheDocument();
+});
+
+test('Unpublish button does NOT show a confirmation dialog', () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    json: async () => ({ success: true, data: {} }),
+  });
+  render(<PublishReportButton reportId="r1" isPublished={true} />);
+  fireEvent.click(screen.getByRole('button', { name: /unpublish/i }));
+  expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+});
+
+test('publish API is NOT called before confirmation', () => {
+  global.fetch = vi.fn();
+  render(<PublishReportButton reportId="r1" isPublished={false} />);
+  fireEvent.click(screen.getByRole('button', { name: /^publish$/i }));
+  expect(global.fetch).not.toHaveBeenCalled();
+});
+
+test('publish API is called after confirmation', async () => {
+  global.fetch = vi.fn().mockResolvedValue({
+    json: async () => ({ success: true, data: {} }),
+  });
+  render(<PublishReportButton reportId="r1" isPublished={false} />);
+  // Open dialog
+  fireEvent.click(screen.getByRole('button', { name: /^publish$/i }));
+  // Click the confirm Publish action in the dialog
+  const confirmButtons = screen.getAllByRole('button', { name: /^publish$/i });
+  // The last Publish button is the action (in dialog)
+  fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith('/api/reports/r1/publish', { method: 'POST' });
+  });
+});

--- a/src/components/__tests__/reports/publish-report-button.test.tsx
+++ b/src/components/__tests__/reports/publish-report-button.test.tsx
@@ -66,7 +66,7 @@ test('publish API is called after confirmation', async () => {
   // Click the confirm Publish action in the dialog
   const confirmButtons = screen.getAllByRole('button', { name: /^publish$/i });
   // The last Publish button is the action (in dialog)
-  fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+  fireEvent.click(confirmButtons[confirmButtons.length - 1]!);
   await waitFor(() => {
     expect(global.fetch).toHaveBeenCalledWith('/api/reports/r1/publish', { method: 'POST' });
   });

--- a/src/components/__tests__/reports/report-badge-utils.test.ts
+++ b/src/components/__tests__/reports/report-badge-utils.test.ts
@@ -1,0 +1,25 @@
+import { getTypeBadgeClass, getStatusBadgeClass } from '@/components/reports/report-badge-utils';
+
+describe('getTypeBadgeClass', () => {
+  test('returns blue classes for executive', () => {
+    expect(getTypeBadgeClass('executive')).toBe('bg-blue-100 text-blue-800 border-blue-200');
+  });
+
+  test('returns purple classes for detailed', () => {
+    expect(getTypeBadgeClass('detailed')).toBe('bg-purple-100 text-purple-800 border-purple-200');
+  });
+
+  test('returns gray classes for custom', () => {
+    expect(getTypeBadgeClass('custom')).toBe('bg-gray-100 text-gray-800 border-gray-200');
+  });
+});
+
+describe('getStatusBadgeClass', () => {
+  test('returns green classes for published', () => {
+    expect(getStatusBadgeClass('published')).toBe('bg-green-100 text-green-800 border-green-200');
+  });
+
+  test('returns yellow classes for draft', () => {
+    expect(getStatusBadgeClass('draft')).toBe('bg-yellow-100 text-yellow-800 border-yellow-200');
+  });
+});

--- a/src/components/__tests__/reports/report-card.test.tsx
+++ b/src/components/__tests__/reports/report-card.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { ReportCard } from '@/components/reports/report-card';
+
+const mockReport = {
+  id: '1',
+  project_id: 'proj-1',
+  title: 'Q1 Accessibility Report',
+  type: 'executive' as const,
+  content: '[]',
+  template_id: null,
+  ai_generated: 0,
+  created_by: null,
+  published_at: null,
+  status: 'draft' as const,
+  created_at: '2026-01-01T00:00:00',
+  updated_at: '2026-01-15T00:00:00',
+};
+
+test('renders report title', () => {
+  render(<ReportCard report={mockReport} />);
+  expect(screen.getByText('Q1 Accessibility Report')).toBeInTheDocument();
+});
+
+test('renders type badge', () => {
+  render(<ReportCard report={mockReport} />);
+  expect(screen.getByText(/executive/i)).toBeInTheDocument();
+});
+
+test('renders status badge', () => {
+  render(<ReportCard report={mockReport} />);
+  expect(screen.getByText(/draft/i)).toBeInTheDocument();
+});
+
+test('links to report detail page', () => {
+  render(<ReportCard report={mockReport} />);
+  expect(screen.getByRole('link')).toHaveAttribute('href', '/reports/1');
+});

--- a/src/components/__tests__/reports/report-card.test.tsx
+++ b/src/components/__tests__/reports/report-card.test.tsx
@@ -35,3 +35,14 @@ test('links to report detail page', () => {
   render(<ReportCard report={mockReport} />);
   expect(screen.getByRole('link')).toHaveAttribute('href', '/reports/1');
 });
+
+test('renders updated_at date formatted as locale string', () => {
+  render(<ReportCard report={mockReport} />);
+  const expectedDate = new Date('2026-01-15T00:00:00').toLocaleDateString();
+  expect(screen.getByText(`Updated ${expectedDate}`)).toBeInTheDocument();
+});
+
+test('renders "Unknown" for invalid updated_at date', () => {
+  render(<ReportCard report={{ ...mockReport, updated_at: 'not-a-date' }} />);
+  expect(screen.getByText('Updated Unknown')).toBeInTheDocument();
+});

--- a/src/components/__tests__/reports/section-editor.test.tsx
+++ b/src/components/__tests__/reports/section-editor.test.tsx
@@ -26,3 +26,10 @@ test('removing a section calls onChange without it', () => {
   fireEvent.click(screen.getAllByRole('button', { name: /remove/i })[0]);
   expect(onChange).toHaveBeenCalledWith([{ title: 'Section 2', content: 'Content 2' }]);
 });
+
+test('updating section title calls onChange with new value', () => {
+  const onChange = vi.fn();
+  render(<SectionEditor sections={[{ title: 'Old', content: '' }]} onChange={onChange} />);
+  fireEvent.change(screen.getByDisplayValue('Old'), { target: { value: 'New' } });
+  expect(onChange).toHaveBeenCalledWith([{ title: 'New', content: '' }]);
+});

--- a/src/components/__tests__/reports/section-editor.test.tsx
+++ b/src/components/__tests__/reports/section-editor.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { SectionEditor } from '@/components/reports/section-editor';
+
+test('renders existing sections', () => {
+  render(
+    <SectionEditor sections={[{ title: 'Overview', content: 'Some content' }]} onChange={vi.fn()} />
+  );
+  expect(screen.getByDisplayValue('Overview')).toBeInTheDocument();
+});
+
+test('add section button creates new empty section', () => {
+  const onChange = vi.fn();
+  render(<SectionEditor sections={[]} onChange={onChange} />);
+  fireEvent.click(screen.getByRole('button', { name: /add section/i }));
+  expect(onChange).toHaveBeenCalledWith([{ title: '', content: '' }]);
+});
+
+test('removing a section calls onChange without it', () => {
+  const onChange = vi.fn();
+  const sections = [
+    { title: 'Section 1', content: 'Content 1' },
+    { title: 'Section 2', content: 'Content 2' },
+  ];
+  render(<SectionEditor sections={sections} onChange={onChange} />);
+  fireEvent.click(screen.getAllByRole('button', { name: /remove/i })[0]);
+  expect(onChange).toHaveBeenCalledWith([{ title: 'Section 2', content: 'Content 2' }]);
+});

--- a/src/components/__tests__/reports/section-editor.test.tsx
+++ b/src/components/__tests__/reports/section-editor.test.tsx
@@ -23,7 +23,7 @@ test('removing a section calls onChange without it', () => {
     { title: 'Section 2', content: 'Content 2' },
   ];
   render(<SectionEditor sections={sections} onChange={onChange} />);
-  fireEvent.click(screen.getAllByRole('button', { name: /remove/i })[0]);
+  fireEvent.click(screen.getAllByRole('button', { name: /remove/i })[0]!);
   expect(onChange).toHaveBeenCalledWith([{ title: 'Section 2', content: 'Content 2' }]);
 });
 

--- a/src/components/reports/delete-report-button.tsx
+++ b/src/components/reports/delete-report-button.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteReportButtonProps {
+  reportId: string;
+  reportTitle: string;
+}
+
+export function DeleteReportButton({ reportId, reportTitle }: DeleteReportButtonProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/reports/${reportId}`, { method: 'DELETE' });
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to delete report');
+        return;
+      }
+      toast.success('Report deleted');
+      router.push('/reports');
+      router.refresh();
+    } catch {
+      toast.error('Failed to delete report');
+    } finally {
+      setIsDeleting(false);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Report</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete &ldquo;{reportTitle}&rdquo;? This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/reports/publish-report-button.tsx
+++ b/src/components/reports/publish-report-button.tsx
@@ -4,6 +4,17 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { Send, SendHorizonal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 interface PublishReportButtonProps {
   reportId: string;
@@ -12,6 +23,7 @@ interface PublishReportButtonProps {
 
 export function PublishReportButton({ reportId, isPublished }: PublishReportButtonProps) {
   const router = useRouter();
+  const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   async function handlePublish() {
@@ -29,6 +41,7 @@ export function PublishReportButton({ reportId, isPublished }: PublishReportButt
       toast.error('Failed to publish report');
     } finally {
       setIsLoading(false);
+      setOpen(false);
     }
   }
 
@@ -60,9 +73,27 @@ export function PublishReportButton({ reportId, isPublished }: PublishReportButt
   }
 
   return (
-    <Button variant="default" size="sm" onClick={handlePublish} disabled={isLoading}>
-      <Send className="mr-2 h-4 w-4" />
-      {isLoading ? 'Publishing…' : 'Publish'}
-    </Button>
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="default" size="sm" disabled={isLoading}>
+          <Send className="mr-2 h-4 w-4" />
+          Publish
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Publish Report</AlertDialogTitle>
+          <AlertDialogDescription>
+            Once published, this report cannot be edited. Are you sure you want to publish?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handlePublish} disabled={isLoading}>
+            {isLoading ? 'Publishing…' : 'Publish'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/components/reports/publish-report-button.tsx
+++ b/src/components/reports/publish-report-button.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { Send } from 'lucide-react';
+import { Send, SendHorizonal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface PublishReportButtonProps {
@@ -23,7 +23,7 @@ export function PublishReportButton({ reportId, isPublished }: PublishReportButt
         toast.error(json.error ?? 'Failed to publish report');
         return;
       }
-      toast.success(isPublished ? 'Report updated' : 'Report published');
+      toast.success('Report published');
       router.refresh();
     } catch {
       toast.error('Failed to publish report');
@@ -32,10 +32,37 @@ export function PublishReportButton({ reportId, isPublished }: PublishReportButt
     }
   }
 
+  async function handleUnpublish() {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/reports/${reportId}/publish`, { method: 'DELETE' });
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to unpublish report');
+        return;
+      }
+      toast.success('Report unpublished');
+      router.refresh();
+    } catch {
+      toast.error('Failed to unpublish report');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (isPublished) {
+    return (
+      <Button variant="outline" size="sm" onClick={handleUnpublish} disabled={isLoading}>
+        <SendHorizonal className="mr-2 h-4 w-4" />
+        {isLoading ? 'Unpublishing…' : 'Unpublish'}
+      </Button>
+    );
+  }
+
   return (
     <Button variant="default" size="sm" onClick={handlePublish} disabled={isLoading}>
       <Send className="mr-2 h-4 w-4" />
-      {isLoading ? 'Publishing…' : isPublished ? 'Re-publish' : 'Publish'}
+      {isLoading ? 'Publishing…' : 'Publish'}
     </Button>
   );
 }

--- a/src/components/reports/publish-report-button.tsx
+++ b/src/components/reports/publish-report-button.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface PublishReportButtonProps {
+  reportId: string;
+  isPublished: boolean;
+}
+
+export function PublishReportButton({ reportId, isPublished }: PublishReportButtonProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handlePublish() {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/reports/${reportId}/publish`, { method: 'POST' });
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to publish report');
+        return;
+      }
+      toast.success(isPublished ? 'Report updated' : 'Report published');
+      router.refresh();
+    } catch {
+      toast.error('Failed to publish report');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Button variant="default" size="sm" onClick={handlePublish} disabled={isLoading}>
+      <Send className="mr-2 h-4 w-4" />
+      {isLoading ? 'Publishing…' : isPublished ? 'Re-publish' : 'Publish'}
+    </Button>
+  );
+}

--- a/src/components/reports/report-badge-utils.ts
+++ b/src/components/reports/report-badge-utils.ts
@@ -1,0 +1,23 @@
+import type { Report } from '@/lib/db/reports';
+
+export function getTypeBadgeClass(type: Report['type']): string {
+  switch (type) {
+    case 'executive':
+      return 'bg-blue-100 text-blue-800 border-blue-200';
+    case 'detailed':
+      return 'bg-purple-100 text-purple-800 border-purple-200';
+    case 'custom':
+    default:
+      return 'bg-gray-100 text-gray-800 border-gray-200';
+  }
+}
+
+export function getStatusBadgeClass(status: Report['status']): string {
+  switch (status) {
+    case 'published':
+      return 'bg-green-100 text-green-800 border-green-200';
+    case 'draft':
+    default:
+      return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+  }
+}

--- a/src/components/reports/report-card.tsx
+++ b/src/components/reports/report-card.tsx
@@ -2,35 +2,15 @@ import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import type { Report } from '@/lib/db/reports';
-
-function getTypeBadgeClass(type: Report['type']): string {
-  switch (type) {
-    case 'executive':
-      return 'bg-blue-100 text-blue-800 border-blue-200';
-    case 'detailed':
-      return 'bg-purple-100 text-purple-800 border-purple-200';
-    case 'custom':
-    default:
-      return 'bg-gray-100 text-gray-800 border-gray-200';
-  }
-}
-
-function getStatusBadgeClass(status: Report['status']): string {
-  switch (status) {
-    case 'published':
-      return 'bg-green-100 text-green-800 border-green-200';
-    case 'draft':
-    default:
-      return 'bg-yellow-100 text-yellow-800 border-yellow-200';
-  }
-}
+import { getTypeBadgeClass, getStatusBadgeClass } from './report-badge-utils';
 
 interface ReportCardProps {
   report: Report;
 }
 
 export function ReportCard({ report }: ReportCardProps) {
-  const updatedDate = new Date(report.updated_at).toLocaleDateString();
+  const dateObj = new Date(report.updated_at);
+  const updatedDate = isNaN(dateObj.getTime()) ? 'Unknown' : dateObj.toLocaleDateString();
 
   return (
     <Link href={`/reports/${report.id}`}>

--- a/src/components/reports/report-card.tsx
+++ b/src/components/reports/report-card.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { Report } from '@/lib/db/reports';
+
+function getTypeBadgeClass(type: Report['type']): string {
+  switch (type) {
+    case 'executive':
+      return 'bg-blue-100 text-blue-800 border-blue-200';
+    case 'detailed':
+      return 'bg-purple-100 text-purple-800 border-purple-200';
+    case 'custom':
+    default:
+      return 'bg-gray-100 text-gray-800 border-gray-200';
+  }
+}
+
+function getStatusBadgeClass(status: Report['status']): string {
+  switch (status) {
+    case 'published':
+      return 'bg-green-100 text-green-800 border-green-200';
+    case 'draft':
+    default:
+      return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+  }
+}
+
+interface ReportCardProps {
+  report: Report;
+}
+
+export function ReportCard({ report }: ReportCardProps) {
+  const updatedDate = new Date(report.updated_at).toLocaleDateString();
+
+  return (
+    <Link href={`/reports/${report.id}`}>
+      <Card className="hover:shadow-md transition-shadow cursor-pointer">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="text-base">{report.title}</CardTitle>
+            <div className="flex gap-2 shrink-0">
+              <Badge className={getTypeBadgeClass(report.type)} variant="outline">
+                {report.type}
+              </Badge>
+              <Badge className={getStatusBadgeClass(report.status)} variant="outline">
+                {report.status}
+              </Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">Updated {updatedDate}</p>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/reports/report-form.tsx
+++ b/src/components/reports/report-form.tsx
@@ -1,0 +1,183 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { SectionEditor } from './section-editor';
+import type { Report } from '@/lib/db/reports';
+
+// SectionEditor uses {title, content}; API uses {title, body}
+interface EditorSection {
+  title: string;
+  content: string;
+}
+
+interface ReportFormProps {
+  /** When provided, the form is in edit mode */
+  report?: Report;
+  /** project_id is required when creating */
+  projectId?: string;
+  projects: { id: string; name: string }[];
+}
+
+export function ReportForm({ report, projects }: ReportFormProps) {
+  const router = useRouter();
+  const isEdit = !!report;
+
+  // Parse existing content (API stores [{title, body}]) into editor format [{title, content}]
+  const initialSections: EditorSection[] = (() => {
+    if (!report) return [];
+    try {
+      const raw = JSON.parse(report.content) as { title: string; body: string }[];
+      return raw.map((s) => ({ title: s.title, content: s.body }));
+    } catch {
+      return [];
+    }
+  })();
+
+  const [title, setTitle] = useState(report?.title ?? '');
+  const [type, setType] = useState<'executive' | 'detailed' | 'custom'>(report?.type ?? 'detailed');
+  const [projectId, setProjectId] = useState(report?.project_id ?? projects[0]?.id ?? '');
+  const [sections, setSections] = useState<EditorSection[]>(initialSections);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+
+    // Map editor sections back to API format
+    const content = sections.map((s) => ({ title: s.title, body: s.content }));
+
+    setIsSubmitting(true);
+    try {
+      let res: Response;
+      if (isEdit) {
+        res = await fetch(`/api/reports/${report.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title, type, content }),
+        });
+      } else {
+        res = await fetch('/api/reports', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ project_id: projectId, title, type, content }),
+        });
+      }
+
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to save report');
+        return;
+      }
+
+      toast.success(isEdit ? 'Report updated' : 'Report created');
+      router.push(`/reports/${json.data.id}`);
+      router.refresh();
+    } catch {
+      toast.error('Failed to save report');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-[1fr_300px]">
+        {/* Left column: form fields */}
+        <div className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Q1 2026 Accessibility Report"
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="type">Report Type</Label>
+              <Select value={type} onValueChange={(v) => setType(v as typeof type)}>
+                <SelectTrigger id="type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="executive">Executive</SelectItem>
+                  <SelectItem value="detailed">Detailed</SelectItem>
+                  <SelectItem value="custom">Custom</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {!isEdit && (
+              <div className="space-y-2">
+                <Label htmlFor="project">Project</Label>
+                <Select value={projectId} onValueChange={setProjectId}>
+                  <SelectTrigger id="project">
+                    <SelectValue placeholder="Select project" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {projects.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {p.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Sections</Label>
+            <SectionEditor sections={sections} onChange={setSections} />
+          </div>
+        </div>
+
+        {/* Right column: reference info */}
+        <aside className="space-y-4">
+          <div className="rounded-lg border p-4">
+            <h2 className="text-sm font-semibold mb-2 text-muted-foreground uppercase tracking-wide">
+              Tips
+            </h2>
+            <ul className="text-sm space-y-2 text-muted-foreground">
+              <li>Add sections to structure your report.</li>
+              <li>Each section has a title and body content.</li>
+              <li>Markdown formatting is supported in section content.</li>
+              <li>Published reports cannot be edited.</li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+
+      <div className="flex gap-3">
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Report'}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => router.back()}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/reports/report-form.tsx
+++ b/src/components/reports/report-form.tsx
@@ -13,23 +13,16 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { SectionEditor } from './section-editor';
-import type { Report } from '@/lib/db/reports';
-
-// SectionEditor uses {title, content}; API uses {title, body}
-interface EditorSection {
-  title: string;
-  content: string;
-}
+import type { EditorSection } from './section-editor';
+import type { Report, ReportSection } from '@/lib/db/reports';
 
 interface ReportFormProps {
   /** When provided, the form is in edit mode */
   report?: Report;
-  /** project_id is required when creating */
-  projectId?: string;
-  projects: { id: string; name: string }[];
+  projects?: { id: string; name: string }[];
 }
 
-export function ReportForm({ report, projects }: ReportFormProps) {
+export function ReportForm({ report, projects = [] }: ReportFormProps) {
   const router = useRouter();
   const isEdit = !!report;
 
@@ -37,7 +30,7 @@ export function ReportForm({ report, projects }: ReportFormProps) {
   const initialSections: EditorSection[] = (() => {
     if (!report) return [];
     try {
-      const raw = JSON.parse(report.content) as { title: string; body: string }[];
+      const raw = JSON.parse(report.content) as ReportSection[];
       return raw.map((s) => ({ title: s.title, content: s.body }));
     } catch {
       return [];
@@ -58,7 +51,7 @@ export function ReportForm({ report, projects }: ReportFormProps) {
     }
 
     // Map editor sections back to API format
-    const content = sections.map((s) => ({ title: s.title, body: s.content }));
+    const content: ReportSection[] = sections.map((s) => ({ title: s.title, body: s.content }));
 
     setIsSubmitting(true);
     try {

--- a/src/components/reports/section-editor.tsx
+++ b/src/components/reports/section-editor.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { X, Plus } from 'lucide-react';
+
+interface Section {
+  title: string;
+  content: string;
+}
+
+interface SectionEditorProps {
+  sections: Section[];
+  onChange: (sections: Section[]) => void;
+}
+
+export function SectionEditor({ sections, onChange }: SectionEditorProps) {
+  const addSection = () => onChange([...sections, { title: '', content: '' }]);
+
+  const removeSection = (index: number) => onChange(sections.filter((_, i) => i !== index));
+
+  const updateSection = (index: number, field: keyof Section, value: string) => {
+    const updated = sections.map((s, i) => (i === index ? { ...s, [field]: value } : s));
+    onChange(updated);
+  };
+
+  return (
+    <div className="space-y-4">
+      {sections.map((section, index) => (
+        <div key={index} className="rounded-lg border p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <Label htmlFor={`section-title-${index}`}>Section Title</Label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => removeSection(index)}
+              aria-label="Remove section"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <Input
+            id={`section-title-${index}`}
+            value={section.title}
+            onChange={(e) => updateSection(index, 'title', e.target.value)}
+            placeholder="Section title"
+          />
+          <Textarea
+            value={section.content}
+            onChange={(e) => updateSection(index, 'content', e.target.value)}
+            placeholder="Section content (markdown supported)"
+            rows={6}
+          />
+        </div>
+      ))}
+      <Button type="button" variant="outline" onClick={addSection}>
+        <Plus className="mr-2 h-4 w-4" />
+        Add Section
+      </Button>
+    </div>
+  );
+}

--- a/src/components/reports/section-editor.tsx
+++ b/src/components/reports/section-editor.tsx
@@ -5,14 +5,15 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { X, Plus } from 'lucide-react';
 
-interface Section {
+/** Shape used by the editor UI (content field maps to body in the DB/API) */
+export interface EditorSection {
   title: string;
   content: string;
 }
 
 interface SectionEditorProps {
-  sections: Section[];
-  onChange: (sections: Section[]) => void;
+  sections: EditorSection[];
+  onChange: (sections: EditorSection[]) => void;
 }
 
 export function SectionEditor({ sections, onChange }: SectionEditorProps) {
@@ -20,7 +21,7 @@ export function SectionEditor({ sections, onChange }: SectionEditorProps) {
 
   const removeSection = (index: number) => onChange(sections.filter((_, i) => i !== index));
 
-  const updateSection = (index: number, field: keyof Section, value: string) => {
+  const updateSection = (index: number, field: keyof EditorSection, value: string) => {
     const updated = sections.map((s, i) => (i === index ? { ...s, [field]: value } : s));
     onChange(updated);
   };
@@ -28,7 +29,7 @@ export function SectionEditor({ sections, onChange }: SectionEditorProps) {
   return (
     <div className="space-y-4">
       {sections.map((section, index) => (
-        <div key={index} className="rounded-lg border p-4 space-y-3">
+        <div key={`section-${index}`} className="rounded-lg border p-4 space-y-3">
           <div className="flex items-center justify-between">
             <Label htmlFor={`section-title-${index}`}>Section Title</Label>
             <Button

--- a/src/lib/db/__tests__/reports.test.ts
+++ b/src/lib/db/__tests__/reports.test.ts
@@ -9,6 +9,7 @@ import {
   updateReport,
   deleteReport,
   publishReport,
+  unpublishReport,
 } from '../reports';
 
 let projectId: string;
@@ -200,5 +201,27 @@ describe('publishReport', () => {
     const second = publishReport(created.id);
     expect(second?.status).toBe('published');
     expect(second?.published_at).toBe(first?.published_at);
+  });
+});
+
+describe('unpublishReport', () => {
+  it('reverts a published report back to draft and clears published_at', () => {
+    const created = createReport({ title: 'To Unpublish', project_id: projectId });
+    publishReport(created.id);
+    const unpublished = unpublishReport(created.id);
+    expect(unpublished).not.toBeNull();
+    expect(unpublished!.status).toBe('draft');
+    expect(unpublished!.published_at).toBeNull();
+  });
+
+  it('is idempotent — unpublishing a draft report returns it unchanged', () => {
+    const created = createReport({ title: 'Already Draft', project_id: projectId });
+    const result = unpublishReport(created.id);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('draft');
+  });
+
+  it('returns null for nonexistent id', () => {
+    expect(unpublishReport('ghost-id')).toBeNull();
   });
 });

--- a/src/lib/db/reports.ts
+++ b/src/lib/db/reports.ts
@@ -1,6 +1,12 @@
 import { getDb } from './index';
 import type { CreateReportInput, UpdateReportInput } from '../validators/reports';
 
+/** Shape of a section as stored in the DB/API (content JSON: [{title, body}]) */
+export interface ReportSection {
+  title: string;
+  body: string;
+}
+
 export interface Report {
   id: string;
   project_id: string;

--- a/src/lib/db/reports.ts
+++ b/src/lib/db/reports.ts
@@ -112,3 +112,19 @@ export function publishReport(id: string): Report | null {
 
   return getReport(id);
 }
+
+export function unpublishReport(id: string): Report | null {
+  const existing = getReport(id);
+  if (!existing) return null;
+
+  // Already draft — return as-is
+  if (existing.status === 'draft') return existing;
+
+  getDb()
+    .prepare(
+      `UPDATE reports SET status = 'draft', published_at = NULL, updated_at = datetime('now') WHERE id = ?`
+    )
+    .run(id);
+
+  return getReport(id);
+}


### PR DESCRIPTION
## Summary
- Reports list/detail/create/edit pages under `/projects/:id/reports`
- `SectionEditor` for managing report sections (add/remove/reorder)
- `PublishReportButton` with `AlertDialog` confirmation for irreversible publish action
- Unpublish support for correcting mistakes

## Test Plan
- [ ] Unit tests: 41 files, 435 tests passing
- [ ] Lint, type-check, format all clean
- [ ] Create report with sections → publish → unpublish