### PR TITLE
feat(#14): add issues UI with WCAG selector and severity badges

### DIFF
--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/edit/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/edit/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+import { useParams, useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
+import { ChevronLeft } from 'lucide-react';
+import Link from 'next/link';
+import { IssueForm } from '@/components/issues/issue-form';
+import type { Issue } from '@/lib/db/issues';
+import type { UpdateIssueInput } from '@/lib/validators/issues';
+
+export default function EditIssuePage() {
+  const params = useParams();
+  const projectId = params.projectId as string;
+  const assessmentId = params.assessmentId as string;
+  const issueId = params.issueId as string;
+  const router = useRouter();
+
+  const [issue, setIssue] = useState<Issue | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.success) setIssue(json.data);
+        else toast.error('Failed to load issue');
+      })
+      .catch(() => toast.error('Failed to load issue'))
+      .finally(() => setFetching(false));
+  }, [projectId, assessmentId, issueId]);
+
+  const handleSubmit = async (data: UpdateIssueInput) => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        }
+      );
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success('Issue updated');
+      router.push(`/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`);
+    } catch {
+      toast.error('Failed to update issue');
+      setLoading(false);
+    }
+  };
+
+  if (fetching) {
+    return <div className="p-6 text-muted-foreground">Loading…</div>;
+  }
+
+  if (!issue) {
+    return <div className="p-6 text-destructive">Issue not found.</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href={`/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to Issue
+      </Link>
+      <h1 className="text-2xl font-bold">Edit Issue</h1>
+      <IssueForm issue={issue} onSubmit={handleSubmit} loading={loading} />
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/page.tsx
@@ -1,0 +1,241 @@
+import Link from 'next/link';
+import { Pencil } from 'lucide-react';
+import { notFound } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getProject } from '@/lib/db/projects';
+import { getAssessment } from '@/lib/db/assessments';
+import { getIssue } from '@/lib/db/issues';
+import { SeverityBadge } from '@/components/issues/severity-badge';
+import { DeleteIssueButton } from '@/components/issues/delete-issue-button';
+
+export const dynamic = 'force-dynamic';
+
+const statusConfig: Record<string, { label: string; className: string }> = {
+  open: { label: 'Open', className: 'bg-blue-100 text-blue-700' },
+  resolved: { label: 'Resolved', className: 'bg-green-100 text-green-700' },
+  wont_fix: { label: "Won't Fix", className: 'bg-gray-100 text-gray-700' },
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default async function IssueDetailPage({
+  params,
+}: {
+  params: Promise<{ projectId: string; assessmentId: string; issueId: string }>;
+}) {
+  const { projectId, assessmentId, issueId } = await params;
+
+  const project = getProject(projectId);
+  if (!project) notFound();
+
+  const assessment = getAssessment(assessmentId);
+  if (!assessment) notFound();
+
+  const issue = getIssue(issueId);
+  if (!issue) notFound();
+
+  const statusConf = statusConfig[issue.status] ?? { label: issue.status, className: '' };
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-1 text-sm text-muted-foreground">
+        <Link href="/projects" className="hover:text-foreground">
+          Projects
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}`} className="hover:text-foreground">
+          {project.name}
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}/assessments`} className="hover:text-foreground">
+          Assessments
+        </Link>
+        <span>/</span>
+        <Link
+          href={`/projects/${projectId}/assessments/${assessmentId}`}
+          className="hover:text-foreground"
+        >
+          {assessment.name}
+        </Link>
+        <span>/</span>
+        <Link
+          href={`/projects/${projectId}/assessments/${assessmentId}/issues`}
+          className="hover:text-foreground"
+        >
+          Issues
+        </Link>
+        <span>/</span>
+        <span className="text-foreground truncate max-w-[200px]">{issue.title}</span>
+      </nav>
+
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h1 className="text-2xl font-bold">{issue.title}</h1>
+            <SeverityBadge severity={issue.severity} />
+            <Badge className={statusConf.className}>{statusConf.label}</Badge>
+          </div>
+          {issue.url && (
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-primary hover:underline break-all"
+            >
+              {issue.url}
+            </a>
+          )}
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <Button variant="outline" asChild>
+            <Link
+              href={`/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}/edit`}
+            >
+              <Pencil className="mr-2 h-4 w-4" />
+              Edit
+            </Link>
+          </Button>
+          <DeleteIssueButton
+            projectId={projectId}
+            assessmentId={assessmentId}
+            issueId={issueId}
+            issueTitle={issue.title}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main content */}
+        <div className="lg:col-span-2 space-y-6">
+          {issue.description && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Description</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm whitespace-pre-wrap">{issue.description}</p>
+              </CardContent>
+            </Card>
+          )}
+
+          {issue.wcag_codes.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>WCAG Criteria</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  {issue.wcag_codes.map((code) => (
+                    <Badge key={code} variant="outline" className="font-mono">
+                      {code}
+                    </Badge>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {issue.tags.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Tags</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-wrap gap-2">
+                  {issue.tags.map((tag) => (
+                    <Badge key={tag} variant="secondary">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {issue.evidence_media.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Evidence</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {issue.evidence_media.map((url, idx) => {
+                    const isVideo = /\.(mp4|webm|ogg)$/i.test(url);
+                    return isVideo ? (
+                      <video key={idx} src={url} controls className="rounded-md w-full" />
+                    ) : (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        key={idx}
+                        src={url}
+                        alt={`Evidence ${idx + 1}`}
+                        className="rounded-md w-full object-cover"
+                      />
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <aside className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Environment</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {[
+                { label: 'Device', value: issue.device_type },
+                { label: 'Browser', value: issue.browser },
+                { label: 'OS', value: issue.operating_system },
+                { label: 'Assistive Tech', value: issue.assistive_technology },
+              ].map(({ label, value }) => (
+                <div key={label}>
+                  <span className="text-muted-foreground">{label}</span>
+                  <p className="font-medium">{value ?? '—'}</p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Dates</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div>
+                <span className="text-muted-foreground">Created</span>
+                <p className="font-medium">{formatDate(issue.created_at)}</p>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Updated</span>
+                <p className="font-medium">{formatDate(issue.updated_at)}</p>
+              </div>
+              {issue.resolved_at && (
+                <div>
+                  <span className="text-muted-foreground">Resolved</span>
+                  <p className="font-medium">{formatDate(issue.resolved_at)}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/page.tsx
@@ -8,15 +8,10 @@ import { getProject } from '@/lib/db/projects';
 import { getAssessment } from '@/lib/db/assessments';
 import { getIssue } from '@/lib/db/issues';
 import { SeverityBadge } from '@/components/issues/severity-badge';
+import { StatusBadge } from '@/components/issues/status-badge';
 import { DeleteIssueButton } from '@/components/issues/delete-issue-button';
 
 export const dynamic = 'force-dynamic';
-
-const statusConfig: Record<string, { label: string; className: string }> = {
-  open: { label: 'Open', className: 'bg-blue-100 text-blue-700' },
-  resolved: { label: 'Resolved', className: 'bg-green-100 text-green-700' },
-  wont_fix: { label: "Won't Fix", className: 'bg-gray-100 text-gray-700' },
-};
 
 function formatDate(iso: string | null): string {
   if (!iso) return '—';
@@ -44,8 +39,6 @@ export default async function IssueDetailPage({
 
   const issue = getIssue(issueId);
   if (!issue) notFound();
-
-  const statusConf = statusConfig[issue.status] ?? { label: issue.status, className: '' };
 
   return (
     <div className="space-y-6">
@@ -86,7 +79,7 @@ export default async function IssueDetailPage({
           <div className="flex items-center gap-3 flex-wrap">
             <h1 className="text-2xl font-bold">{issue.title}</h1>
             <SeverityBadge severity={issue.severity} />
-            <Badge className={statusConf.className}>{statusConf.label}</Badge>
+            <StatusBadge status={issue.status} />
           </div>
           {issue.url && (
             <a

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/new/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/new/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useParams, useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { ChevronLeft } from 'lucide-react';
+import Link from 'next/link';
+import { IssueForm } from '@/components/issues/issue-form';
+import type { CreateIssueInput, UpdateIssueInput } from '@/lib/validators/issues';
+
+export default function NewIssuePage() {
+  const params = useParams();
+  const projectId = params.projectId as string;
+  const assessmentId = params.assessmentId as string;
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (data: CreateIssueInput | UpdateIssueInput) => {
+    setLoading(true);
+    try {
+      const payload = data as CreateIssueInput;
+      const res = await fetch(`/api/projects/${projectId}/assessments/${assessmentId}/issues`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success('Issue created');
+      router.push(`/projects/${projectId}/assessments/${assessmentId}/issues/${json.data.id}`);
+    } catch {
+      toast.error('Failed to create issue');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href={`/projects/${projectId}/assessments/${assessmentId}/issues`}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to Issues
+      </Link>
+      <h1 className="text-2xl font-bold">New Issue</h1>
+      <IssueForm onSubmit={handleSubmit} loading={loading} />
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/page.tsx
@@ -1,0 +1,175 @@
+import Link from 'next/link';
+import { Plus } from 'lucide-react';
+import { notFound } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { getProject } from '@/lib/db/projects';
+import { getAssessment } from '@/lib/db/assessments';
+import { getIssues } from '@/lib/db/issues';
+import { SeverityBadge } from '@/components/issues/severity-badge';
+import type { IssueFilters } from '@/lib/db/issues';
+
+export const dynamic = 'force-dynamic';
+
+const statusConfig: Record<string, { label: string; className: string }> = {
+  open: { label: 'Open', className: 'bg-blue-100 text-blue-700' },
+  resolved: { label: 'Resolved', className: 'bg-green-100 text-green-700' },
+  wont_fix: { label: "Won't Fix", className: 'bg-gray-100 text-gray-700' },
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export default async function IssuesPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ projectId: string; assessmentId: string }>;
+  searchParams: Promise<{ severity?: string }>;
+}) {
+  const { projectId, assessmentId } = await params;
+  const { severity } = await searchParams;
+
+  const project = getProject(projectId);
+  if (!project) notFound();
+
+  const assessment = getAssessment(assessmentId);
+  if (!assessment) notFound();
+
+  const filters: IssueFilters = {};
+  if (severity && ['critical', 'high', 'medium', 'low'].includes(severity)) {
+    filters.severity = severity as IssueFilters['severity'];
+  }
+
+  const issues = getIssues(assessmentId, filters);
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-1 text-sm text-muted-foreground">
+        <Link href="/projects" className="hover:text-foreground">
+          Projects
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}`} className="hover:text-foreground">
+          {project.name}
+        </Link>
+        <span>/</span>
+        <Link href={`/projects/${projectId}/assessments`} className="hover:text-foreground">
+          Assessments
+        </Link>
+        <span>/</span>
+        <Link
+          href={`/projects/${projectId}/assessments/${assessmentId}`}
+          className="hover:text-foreground"
+        >
+          {assessment.name}
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">Issues</span>
+      </nav>
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Issues — {assessment.name}</h1>
+        <Button asChild>
+          <Link href={`/projects/${projectId}/assessments/${assessmentId}/issues/new`}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create Issue
+          </Link>
+        </Button>
+      </div>
+
+      {/* Severity filter */}
+      <div className="flex items-center gap-2 text-sm">
+        <span className="text-muted-foreground">Filter by severity:</span>
+        {(['', 'critical', 'high', 'medium', 'low'] as const).map((s) => (
+          <Link
+            key={s || 'all'}
+            href={
+              s
+                ? `/projects/${projectId}/assessments/${assessmentId}/issues?severity=${s}`
+                : `/projects/${projectId}/assessments/${assessmentId}/issues`
+            }
+            className={`rounded-full px-3 py-1 text-xs font-medium border transition-colors ${
+              (severity ?? '') === s
+                ? 'bg-primary text-primary-foreground border-primary'
+                : 'border-border hover:bg-muted'
+            }`}
+          >
+            {s ? s.charAt(0).toUpperCase() + s.slice(1) : 'All'}
+          </Link>
+        ))}
+      </div>
+
+      {/* Issues table / empty state */}
+      {issues.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <p className="text-muted-foreground">No issues found.</p>
+          <Button asChild className="mt-4">
+            <Link href={`/projects/${projectId}/assessments/${assessmentId}/issues/new`}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create your first issue
+            </Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Title</TableHead>
+                <TableHead>Severity</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {issues.map((issue) => {
+                const statusConf = statusConfig[issue.status] ?? {
+                  label: issue.status,
+                  className: '',
+                };
+                return (
+                  <TableRow key={issue.id}>
+                    <TableCell className="font-medium">
+                      <Link
+                        href={`/projects/${projectId}/assessments/${assessmentId}/issues/${issue.id}`}
+                        className="hover:underline"
+                      >
+                        {issue.title}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      <SeverityBadge severity={issue.severity} />
+                    </TableCell>
+                    <TableCell>
+                      <Badge className={statusConf.className}>{statusConf.label}</Badge>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatDate(issue.created_at)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/page.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import { Plus } from 'lucide-react';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import {
   Table,
   TableBody,
@@ -15,15 +14,10 @@ import { getProject } from '@/lib/db/projects';
 import { getAssessment } from '@/lib/db/assessments';
 import { getIssues } from '@/lib/db/issues';
 import { SeverityBadge } from '@/components/issues/severity-badge';
+import { StatusBadge } from '@/components/issues/status-badge';
 import type { IssueFilters } from '@/lib/db/issues';
 
 export const dynamic = 'force-dynamic';
-
-const statusConfig: Record<string, { label: string; className: string }> = {
-  open: { label: 'Open', className: 'bg-blue-100 text-blue-700' },
-  resolved: { label: 'Resolved', className: 'bg-green-100 text-green-700' },
-  wont_fix: { label: "Won't Fix", className: 'bg-gray-100 text-gray-700' },
-};
 
 function formatDate(iso: string | null): string {
   if (!iso) return '—';
@@ -139,33 +133,27 @@ export default async function IssuesPage({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {issues.map((issue) => {
-                const statusConf = statusConfig[issue.status] ?? {
-                  label: issue.status,
-                  className: '',
-                };
-                return (
-                  <TableRow key={issue.id}>
-                    <TableCell className="font-medium">
-                      <Link
-                        href={`/projects/${projectId}/assessments/${assessmentId}/issues/${issue.id}`}
-                        className="hover:underline"
-                      >
-                        {issue.title}
-                      </Link>
-                    </TableCell>
-                    <TableCell>
-                      <SeverityBadge severity={issue.severity} />
-                    </TableCell>
-                    <TableCell>
-                      <Badge className={statusConf.className}>{statusConf.label}</Badge>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      {formatDate(issue.created_at)}
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
+              {issues.map((issue) => (
+                <TableRow key={issue.id}>
+                  <TableCell className="font-medium">
+                    <Link
+                      href={`/projects/${projectId}/assessments/${assessmentId}/issues/${issue.id}`}
+                      className="hover:underline"
+                    >
+                      {issue.title}
+                    </Link>
+                  </TableCell>
+                  <TableCell>
+                    <SeverityBadge severity={issue.severity} />
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={issue.status} />
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {formatDate(issue.created_at)}
+                  </TableCell>
+                </TableRow>
+              ))}
             </TableBody>
           </Table>
         </div>

--- a/src/components/__tests__/issues/delete-issue-button.test.tsx
+++ b/src/components/__tests__/issues/delete-issue-button.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+// Mock sonner
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// Mock fetch
+global.fetch = vi.fn();
+
+import { DeleteIssueButton } from '@/components/issues/delete-issue-button';
+import { toast } from 'sonner';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders the Delete trigger button', () => {
+  render(
+    <DeleteIssueButton
+      projectId="p1"
+      assessmentId="a1"
+      issueId="i1"
+      issueTitle="Missing alt text"
+    />
+  );
+  expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+});
+
+test('shows the issue title in the confirmation dialog', async () => {
+  render(
+    <DeleteIssueButton
+      projectId="p1"
+      assessmentId="a1"
+      issueId="i1"
+      issueTitle="Missing alt text"
+    />
+  );
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  expect(await screen.findByText(/missing alt text/i)).toBeInTheDocument();
+});
+
+test('calls the correct DELETE API endpoint on confirm', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: true }),
+  });
+
+  render(
+    <DeleteIssueButton
+      projectId="p1"
+      assessmentId="a1"
+      issueId="i1"
+      issueTitle="Missing alt text"
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const confirmButton = await screen.findByRole('button', { name: /delete issue/i });
+  fireEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/projects/p1/assessments/a1/issues/i1',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+});
+
+test('redirects to issues list on success', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: true }),
+  });
+
+  render(
+    <DeleteIssueButton
+      projectId="p1"
+      assessmentId="a1"
+      issueId="i1"
+      issueTitle="Missing alt text"
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const confirmButton = await screen.findByRole('button', { name: /delete issue/i });
+  fireEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(mockPush).toHaveBeenCalledWith('/projects/p1/assessments/a1/issues');
+  });
+});
+
+test('shows an error toast on API failure', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: false }),
+  });
+
+  render(
+    <DeleteIssueButton
+      projectId="p1"
+      assessmentId="a1"
+      issueId="i1"
+      issueTitle="Missing alt text"
+    />
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const confirmButton = await screen.findByRole('button', { name: /delete issue/i });
+  fireEvent.click(confirmButton);
+
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/issues/issue-form.test.tsx
+++ b/src/components/__tests__/issues/issue-form.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { IssueForm } from '@/components/issues/issue-form';
+import type { Issue } from '@/lib/db/issues';
+
+test('renders title field as required', () => {
+  render(<IssueForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/title/i)).toBeRequired();
+});
+
+test('renders description textarea', () => {
+  render(<IssueForm onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+});
+
+test('renders severity select', () => {
+  render(<IssueForm onSubmit={vi.fn()} />);
+  expect(screen.getByRole('combobox', { name: /severity/i })).toBeInTheDocument();
+});
+
+test('renders status select', () => {
+  render(<IssueForm onSubmit={vi.fn()} />);
+  expect(screen.getByRole('combobox', { name: /status/i })).toBeInTheDocument();
+});
+
+test('renders save button', () => {
+  render(<IssueForm onSubmit={vi.fn()} />);
+  expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+});
+
+test('calls onSubmit with form data on submit', () => {
+  const onSubmit = vi.fn();
+  render(<IssueForm onSubmit={onSubmit} />);
+  fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Missing alt text' } });
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+  expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ title: 'Missing alt text' }));
+});
+
+test('pre-fills data when editing existing issue', () => {
+  const issue: Issue = {
+    id: 'i1',
+    assessment_id: 'a1',
+    title: 'Button has no label',
+    description: 'The submit button has no accessible name.',
+    url: 'https://example.com/page',
+    severity: 'high',
+    status: 'open',
+    wcag_codes: ['4.1.2'],
+    ai_suggested_codes: [],
+    ai_confidence_score: null,
+    device_type: 'desktop',
+    browser: 'Chrome',
+    operating_system: 'macOS',
+    assistive_technology: 'VoiceOver',
+    evidence_media: [],
+    tags: ['buttons'],
+    created_by: null,
+    resolved_by: null,
+    resolved_at: null,
+    created_at: '2026-01-01T00:00:00',
+    updated_at: '2026-01-01T00:00:00',
+  };
+  render(<IssueForm issue={issue} onSubmit={vi.fn()} />);
+  expect(screen.getByLabelText(/title/i)).toHaveValue('Button has no label');
+  expect(screen.getByLabelText(/description/i)).toHaveValue(
+    'The submit button has no accessible name.'
+  );
+});
+
+test('shows loading state on button when loading', () => {
+  render(<IssueForm onSubmit={vi.fn()} loading />);
+  expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+});

--- a/src/components/__tests__/issues/severity-badge.test.tsx
+++ b/src/components/__tests__/issues/severity-badge.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { SeverityBadge } from '@/components/issues/severity-badge';
+
+test('renders critical badge with red style', () => {
+  render(<SeverityBadge severity="critical" />);
+  const badge = screen.getByText(/critical/i);
+  expect(badge).toHaveClass('bg-red-500/20');
+});
+
+test('renders high badge with orange style', () => {
+  render(<SeverityBadge severity="high" />);
+  const badge = screen.getByText(/high/i);
+  expect(badge).toHaveClass('bg-orange-500/20');
+});
+
+test('renders medium badge with yellow style', () => {
+  render(<SeverityBadge severity="medium" />);
+  const badge = screen.getByText(/medium/i);
+  expect(badge).toHaveClass('bg-yellow-500/20');
+});
+
+test('renders low badge with blue style', () => {
+  render(<SeverityBadge severity="low" />);
+  const badge = screen.getByText(/low/i);
+  expect(badge).toHaveClass('bg-blue-500/20');
+});

--- a/src/components/__tests__/issues/tag-input.test.tsx
+++ b/src/components/__tests__/issues/tag-input.test.tsx
@@ -34,7 +34,7 @@ test('removes tag on click', () => {
   render(<TagInput tags={['accessibility', 'forms']} onChange={onChange} />);
   const removeButtons = screen.getAllByRole('button');
   // Click the first remove button (for 'accessibility')
-  fireEvent.click(removeButtons[0]);
+  fireEvent.click(removeButtons[0]!);
   expect(onChange).toHaveBeenCalledWith(['forms']);
 });
 

--- a/src/components/__tests__/issues/tag-input.test.tsx
+++ b/src/components/__tests__/issues/tag-input.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { TagInput } from '@/components/issues/tag-input';
+
+test('adds tag on Enter key', () => {
+  const onChange = vi.fn();
+  render(<TagInput tags={[]} onChange={onChange} />);
+  const input = screen.getByPlaceholderText(/add tag/i);
+  fireEvent.change(input, { target: { value: 'accessibility' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(onChange).toHaveBeenCalledWith(['accessibility']);
+});
+
+test('does not add empty tags', () => {
+  const onChange = vi.fn();
+  render(<TagInput tags={[]} onChange={onChange} />);
+  const input = screen.getByPlaceholderText(/add tag/i);
+  fireEvent.change(input, { target: { value: '   ' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test('does not add duplicate tags', () => {
+  const onChange = vi.fn();
+  render(<TagInput tags={['accessibility']} onChange={onChange} />);
+  const input = screen.getByPlaceholderText(/add tag/i);
+  fireEvent.change(input, { target: { value: 'accessibility' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test('removes tag on click', () => {
+  const onChange = vi.fn();
+  render(<TagInput tags={['accessibility', 'forms']} onChange={onChange} />);
+  const removeButtons = screen.getAllByRole('button');
+  // Click the first remove button (for 'accessibility')
+  fireEvent.click(removeButtons[0]);
+  expect(onChange).toHaveBeenCalledWith(['forms']);
+});
+
+test('renders existing tags', () => {
+  render(<TagInput tags={['a11y', 'wcag']} onChange={vi.fn()} />);
+  expect(screen.getByText('a11y')).toBeInTheDocument();
+  expect(screen.getByText('wcag')).toBeInTheDocument();
+});

--- a/src/components/__tests__/issues/wcag-selector.test.tsx
+++ b/src/components/__tests__/issues/wcag-selector.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { WcagSelector } from '@/components/issues/wcag-selector';
+
+test('shows selected codes as badges', () => {
+  render(<WcagSelector selected={['1.1.1']} onChange={vi.fn()} />);
+  // There will be at least one element showing '1.1.1' (as a badge)
+  const matches = screen.getAllByText('1.1.1');
+  expect(matches.length).toBeGreaterThanOrEqual(1);
+});
+
+test('can select a code', () => {
+  const onChange = vi.fn();
+  render(<WcagSelector selected={[]} onChange={onChange} />);
+  // Find the checkbox for 1.1.1 and click it
+  const checkbox = screen.getByRole('checkbox', { name: /1\.1\.1/i });
+  fireEvent.click(checkbox);
+  expect(onChange).toHaveBeenCalledWith(['1.1.1']);
+});
+
+test('can remove a selected code', () => {
+  const onChange = vi.fn();
+  render(<WcagSelector selected={['1.1.1']} onChange={onChange} />);
+  const checkbox = screen.getByRole('checkbox', { name: /1\.1\.1/i });
+  fireEvent.click(checkbox);
+  expect(onChange).toHaveBeenCalledWith([]);
+});
+
+test('shows multiple selected codes as badges', () => {
+  render(<WcagSelector selected={['1.1.1', '1.4.3']} onChange={vi.fn()} />);
+  // Badges shown above the list
+  const badges = screen.getAllByText(/1\.1\.1|1\.4\.3/);
+  expect(badges.length).toBeGreaterThanOrEqual(2);
+});

--- a/src/components/issues/delete-issue-button.tsx
+++ b/src/components/issues/delete-issue-button.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteIssueButtonProps {
+  projectId: string;
+  assessmentId: string;
+  issueId: string;
+  issueTitle: string;
+}
+
+export function DeleteIssueButton({
+  projectId,
+  assessmentId,
+  issueId,
+  issueTitle,
+}: DeleteIssueButtonProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleDelete = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`,
+        { method: 'DELETE' }
+      );
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success('Issue deleted');
+      router.push(`/projects/${projectId}/assessments/${assessmentId}/issues`);
+    } catch {
+      toast.error('Failed to delete issue');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" disabled={loading}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {issueTitle}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete the issue and all associated data. This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Delete Issue
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/issues/issue-form.tsx
+++ b/src/components/issues/issue-form.tsx
@@ -1,0 +1,189 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { WcagSelector } from './wcag-selector';
+import { TagInput } from './tag-input';
+import type { Issue } from '@/lib/db/issues';
+import type { CreateIssueInput, UpdateIssueInput } from '@/lib/validators/issues';
+
+interface IssueFormProps {
+  issue?: Issue;
+  onSubmit: (data: CreateIssueInput | UpdateIssueInput) => void;
+  loading?: boolean;
+}
+
+export function IssueForm({ issue, onSubmit, loading }: IssueFormProps) {
+  const [title, setTitle] = useState(issue?.title ?? '');
+  const [description, setDescription] = useState(issue?.description ?? '');
+  const [url, setUrl] = useState(issue?.url ?? '');
+  const [severity, setSeverity] = useState<Issue['severity']>(issue?.severity ?? 'medium');
+  const [status, setStatus] = useState<Issue['status']>(issue?.status ?? 'open');
+  const [wcagCodes, setWcagCodes] = useState<string[]>(issue?.wcag_codes ?? []);
+  const [tags, setTags] = useState<string[]>(issue?.tags ?? []);
+  const [deviceType, setDeviceType] = useState(issue?.device_type ?? '');
+  const [browser, setBrowser] = useState(issue?.browser ?? '');
+  const [os, setOs] = useState(issue?.operating_system ?? '');
+  const [assistiveTech, setAssistiveTech] = useState(issue?.assistive_technology ?? '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: CreateIssueInput = {
+      title,
+      description: description || undefined,
+      url: url || undefined,
+      severity,
+      status,
+      wcag_codes: wcagCodes as CreateIssueInput['wcag_codes'],
+      tags,
+      device_type: (deviceType as Issue['device_type']) || undefined,
+      browser: browser || undefined,
+      operating_system: os || undefined,
+      assistive_technology: assistiveTech || undefined,
+    };
+    onSubmit(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Left column */}
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="title">Title *</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              placeholder="e.g. Image missing alt text"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+              placeholder="Describe the accessibility issue"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="url">URL</Label>
+            <Input
+              id="url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com/page"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="severity">Severity</Label>
+              <Select value={severity} onValueChange={(v) => setSeverity(v as Issue['severity'])}>
+                <SelectTrigger id="severity">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="critical">Critical</SelectItem>
+                  <SelectItem value="high">High</SelectItem>
+                  <SelectItem value="medium">Medium</SelectItem>
+                  <SelectItem value="low">Low</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="status">Status</Label>
+              <Select value={status} onValueChange={(v) => setStatus(v as Issue['status'])}>
+                <SelectTrigger id="status">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="open">Open</SelectItem>
+                  <SelectItem value="resolved">Resolved</SelectItem>
+                  <SelectItem value="wont_fix">Won&apos;t Fix</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>WCAG Criteria</Label>
+            <WcagSelector selected={wcagCodes} onChange={setWcagCodes} />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Tags</Label>
+            <TagInput tags={tags} onChange={setTags} />
+          </div>
+        </div>
+
+        {/* Right column — environment */}
+        <div className="space-y-4">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Environment
+          </h3>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="device_type">Device Type</Label>
+            <Input
+              id="device_type"
+              value={deviceType}
+              onChange={(e) => setDeviceType(e.target.value)}
+              placeholder="desktop / mobile / tablet"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="browser">Browser</Label>
+            <Input
+              id="browser"
+              value={browser}
+              onChange={(e) => setBrowser(e.target.value)}
+              placeholder="e.g. Chrome 121"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="operating_system">Operating System</Label>
+            <Input
+              id="operating_system"
+              value={os}
+              onChange={(e) => setOs(e.target.value)}
+              placeholder="e.g. macOS 14"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="assistive_technology">Assistive Technology</Label>
+            <Input
+              id="assistive_technology"
+              value={assistiveTech}
+              onChange={(e) => setAssistiveTech(e.target.value)}
+              placeholder="e.g. VoiceOver, NVDA"
+            />
+          </div>
+        </div>
+      </div>
+
+      <Button type="submit" disabled={loading}>
+        {loading ? 'Saving…' : 'Save Issue'}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/issues/issue-form.tsx
+++ b/src/components/issues/issue-form.tsx
@@ -30,7 +30,7 @@ export function IssueForm({ issue, onSubmit, loading }: IssueFormProps) {
   const [status, setStatus] = useState<Issue['status']>(issue?.status ?? 'open');
   const [wcagCodes, setWcagCodes] = useState<string[]>(issue?.wcag_codes ?? []);
   const [tags, setTags] = useState<string[]>(issue?.tags ?? []);
-  const [deviceType, setDeviceType] = useState(issue?.device_type ?? '');
+  const [deviceType, setDeviceType] = useState<Issue['device_type'] | ''>(issue?.device_type ?? '');
   const [browser, setBrowser] = useState(issue?.browser ?? '');
   const [os, setOs] = useState(issue?.operating_system ?? '');
   const [assistiveTech, setAssistiveTech] = useState(issue?.assistive_technology ?? '');
@@ -141,12 +141,20 @@ export function IssueForm({ issue, onSubmit, loading }: IssueFormProps) {
 
           <div className="space-y-1.5">
             <Label htmlFor="device_type">Device Type</Label>
-            <Input
-              id="device_type"
-              value={deviceType}
-              onChange={(e) => setDeviceType(e.target.value)}
-              placeholder="desktop / mobile / tablet"
-            />
+            <Select
+              value={deviceType || 'none'}
+              onValueChange={(v) => setDeviceType(v === 'none' ? '' : (v as Issue['device_type']))}
+            >
+              <SelectTrigger id="device_type">
+                <SelectValue placeholder="Select device type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="desktop">Desktop</SelectItem>
+                <SelectItem value="mobile">Mobile</SelectItem>
+                <SelectItem value="tablet">Tablet</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
 
           <div className="space-y-1.5">

--- a/src/components/issues/severity-badge.tsx
+++ b/src/components/issues/severity-badge.tsx
@@ -1,0 +1,35 @@
+import type { Issue } from '@/lib/db/issues';
+
+const severityConfig: Record<Issue['severity'], { label: string; className: string }> = {
+  critical: {
+    label: 'Critical',
+    className: 'bg-red-500/20 text-red-400 border border-red-500/30',
+  },
+  high: {
+    label: 'High',
+    className: 'bg-orange-500/20 text-orange-400 border border-orange-500/30',
+  },
+  medium: {
+    label: 'Medium',
+    className: 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30',
+  },
+  low: {
+    label: 'Low',
+    className: 'bg-blue-500/20 text-blue-400 border border-blue-500/30',
+  },
+};
+
+interface SeverityBadgeProps {
+  severity: Issue['severity'];
+}
+
+export function SeverityBadge({ severity }: SeverityBadgeProps) {
+  const config = severityConfig[severity];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${config.className}`}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/src/components/issues/status-badge.tsx
+++ b/src/components/issues/status-badge.tsx
@@ -1,0 +1,17 @@
+import { Badge } from '@/components/ui/badge';
+import type { Issue } from '@/lib/db/issues';
+
+const statusConfig: Record<Issue['status'], { label: string; className: string }> = {
+  open: { label: 'Open', className: 'bg-blue-100 text-blue-700' },
+  resolved: { label: 'Resolved', className: 'bg-green-100 text-green-700' },
+  wont_fix: { label: "Won't Fix", className: 'bg-gray-100 text-gray-700' },
+};
+
+interface StatusBadgeProps {
+  status: Issue['status'];
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const config = statusConfig[status] ?? { label: status, className: '' };
+  return <Badge className={config.className}>{config.label}</Badge>;
+}

--- a/src/components/issues/tag-input.tsx
+++ b/src/components/issues/tag-input.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+}
+
+export function TagInput({ tags, onChange, placeholder = 'Add tag…' }: TagInputProps) {
+  const [value, setValue] = useState('');
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      if (tags.includes(trimmed)) return;
+      onChange([...tags, trimmed]);
+      setValue('');
+    }
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(tags.filter((t) => t !== tag));
+  };
+
+  return (
+    <div className="space-y-2">
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="ml-0.5 rounded-full hover:bg-muted-foreground/20"
+                aria-label={`Remove tag ${tag}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/src/components/issues/wcag-selector.tsx
+++ b/src/components/issues/wcag-selector.tsx
@@ -1,19 +1,6 @@
 'use client';
 import { X } from 'lucide-react';
-
-const WCAG_CODES = [
-  { code: '1.1.1', name: 'Non-text Content', level: 'A' },
-  { code: '1.3.1', name: 'Info and Relationships', level: 'A' },
-  { code: '1.4.3', name: 'Contrast (Minimum)', level: 'AA' },
-  { code: '1.4.11', name: 'Non-text Contrast', level: 'AA' },
-  { code: '2.1.1', name: 'Keyboard', level: 'A' },
-  { code: '2.1.2', name: 'No Keyboard Trap', level: 'A' },
-  { code: '2.4.3', name: 'Focus Order', level: 'A' },
-  { code: '2.4.7', name: 'Focus Visible', level: 'AA' },
-  { code: '3.3.1', name: 'Error Identification', level: 'A' },
-  { code: '3.3.3', name: 'Error Suggestion', level: 'AA' },
-  { code: '4.1.2', name: 'Name, Role, Value', level: 'A' },
-];
+import { WCAG_CRITERION_CODES } from '@/lib/constants/wcag';
 
 interface WcagSelectorProps {
   selected: string[];
@@ -51,8 +38,8 @@ export function WcagSelector({ selected, onChange }: WcagSelectorProps) {
           ))}
         </div>
       )}
-      <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
-        {WCAG_CODES.map(({ code, name, level }) => {
+      <div className="max-h-64 overflow-y-auto rounded-md border p-2 space-y-1">
+        {WCAG_CRITERION_CODES.map((code) => {
           const id = `wcag-${code}`;
           return (
             <label
@@ -65,11 +52,9 @@ export function WcagSelector({ selected, onChange }: WcagSelectorProps) {
                 type="checkbox"
                 checked={selected.includes(code)}
                 onChange={() => toggle(code)}
-                aria-label={`${code} ${name}`}
+                aria-label={code}
               />
               <span className="font-mono">{code}</span>
-              <span className="text-muted-foreground">{name}</span>
-              <span className="ml-auto text-xs text-muted-foreground">{level}</span>
             </label>
           );
         })}

--- a/src/components/issues/wcag-selector.tsx
+++ b/src/components/issues/wcag-selector.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { X } from 'lucide-react';
+
+const WCAG_CODES = [
+  { code: '1.1.1', name: 'Non-text Content', level: 'A' },
+  { code: '1.3.1', name: 'Info and Relationships', level: 'A' },
+  { code: '1.4.3', name: 'Contrast (Minimum)', level: 'AA' },
+  { code: '1.4.11', name: 'Non-text Contrast', level: 'AA' },
+  { code: '2.1.1', name: 'Keyboard', level: 'A' },
+  { code: '2.1.2', name: 'No Keyboard Trap', level: 'A' },
+  { code: '2.4.3', name: 'Focus Order', level: 'A' },
+  { code: '2.4.7', name: 'Focus Visible', level: 'AA' },
+  { code: '3.3.1', name: 'Error Identification', level: 'A' },
+  { code: '3.3.3', name: 'Error Suggestion', level: 'AA' },
+  { code: '4.1.2', name: 'Name, Role, Value', level: 'A' },
+];
+
+interface WcagSelectorProps {
+  selected: string[];
+  onChange: (codes: string[]) => void;
+}
+
+export function WcagSelector({ selected, onChange }: WcagSelectorProps) {
+  const toggle = (code: string) => {
+    if (selected.includes(code)) {
+      onChange(selected.filter((c) => c !== code));
+    } else {
+      onChange([...selected, code]);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {selected.map((code) => (
+            <span
+              key={code}
+              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary"
+            >
+              {code}
+              <button
+                type="button"
+                onClick={() => toggle(code)}
+                className="ml-0.5 rounded-full hover:bg-primary/20"
+                aria-label={`Remove WCAG ${code}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="max-h-48 overflow-y-auto rounded-md border p-2 space-y-1">
+        {WCAG_CODES.map(({ code, name, level }) => {
+          const id = `wcag-${code}`;
+          return (
+            <label
+              key={code}
+              htmlFor={id}
+              className="flex items-center gap-2 cursor-pointer p-1 rounded hover:bg-muted text-sm"
+            >
+              <input
+                id={id}
+                type="checkbox"
+                checked={selected.includes(code)}
+                onChange={() => toggle(code)}
+                aria-label={`${code} ${name}`}
+              />
+              <span className="font-mono">{code}</span>
+              <span className="text-muted-foreground">{name}</span>
+              <span className="ml-auto text-xs text-muted-foreground">{level}</span>
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `SeverityBadge` (critical/high/medium/low color-coded), `StatusBadge`, `TagInput`, `WcagSelector` (full 87-criterion list), `IssueForm`, `DeleteIssueButton`
- Issues list with severity filter pills, create/detail/edit pages
- `device_type` enforced as Select (desktop/mobile/tablet), no free-text

## Test Plan
- [ ] Unit tests: 49 files, 469 tests passing
- [ ] Lint, type-check, format all clean
- [ ] Create issue with WCAG codes and tags → filter by severity