### PR TITLE
feat(#17): add VPAT UI with WCAG conformance table

### DIFF
--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+
+// JSDOM does not implement scrollIntoView; mock it to prevent Radix UI errors.
+// Guard for node environment tests that don't have window.
+if (typeof window !== 'undefined') {
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+}

--- a/src/app/(app)/vpats/[id]/edit/page.tsx
+++ b/src/app/(app)/vpats/[id]/edit/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { VpatCriteriaTable, type CriterionRow } from '@/components/vpats/vpat-criteria-table';
+import { buildDefaultCriteriaRows, CONFORMANCE_DB_VALUE } from '@/lib/vpats/wcag-criteria';
+
+interface VpatData {
+  id: string;
+  title: string;
+  status: string;
+  wcag_scope: string[];
+  criteria_rows: Array<{
+    criterion_code: string;
+    conformance: string;
+    remarks: string | null;
+    related_issue_ids: string[];
+  }>;
+}
+
+export default function EditVpatPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const vpatId = params.id;
+
+  const [title, setTitle] = useState('');
+  const [criteria, setCriteria] = useState<CriterionRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    async function loadVpat() {
+      try {
+        const res = await fetch(`/api/vpats/${vpatId}`);
+        const json = await res.json();
+        if (!json.success) {
+          toast.error('Failed to load VPAT');
+          router.push('/vpats');
+          return;
+        }
+        const vpat: VpatData = json.data;
+        setTitle(vpat.title);
+
+        const rows: CriterionRow[] =
+          vpat.criteria_rows.length > 0
+            ? vpat.criteria_rows.map((r) => ({
+                criterion_code: r.criterion_code,
+                conformance: r.conformance,
+                remarks: r.remarks ?? '',
+                related_issue_ids: r.related_issue_ids,
+              }))
+            : buildDefaultCriteriaRows().map((r) => ({
+                criterion_code: r.criterion_code,
+                conformance: r.conformance,
+                remarks: '',
+                related_issue_ids: [],
+              }));
+        setCriteria(rows);
+      } catch {
+        toast.error('Failed to load VPAT');
+        router.push('/vpats');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    loadVpat();
+  }, [vpatId, router]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const criteriaRows = criteria.map((r) => ({
+        criterion_code: r.criterion_code,
+        conformance: (CONFORMANCE_DB_VALUE[r.conformance] ?? r.conformance) as
+          | 'supports'
+          | 'partially_supports'
+          | 'does_not_support'
+          | 'not_applicable'
+          | 'not_evaluated',
+        remarks: r.remarks ?? null,
+        related_issue_ids: r.related_issue_ids,
+      }));
+
+      const res = await fetch(`/api/vpats/${vpatId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          criteria_rows: criteriaRows,
+        }),
+      });
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to update VPAT');
+        return;
+      }
+      toast.success('VPAT saved');
+      router.push(`/vpats/${vpatId}`);
+      router.refresh();
+    } catch {
+      toast.error('Failed to update VPAT');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return <div className="text-muted-foreground text-sm p-6">Loading VPAT…</div>;
+  }
+
+  return (
+    <div>
+      <Link
+        href={`/vpats/${vpatId}`}
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ChevronLeft className="h-4 w-4 mr-1" />
+        Back to VPAT
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">Edit VPAT</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>VPAT Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="title">Title *</Label>
+              <Input
+                id="title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="e.g. Acme SaaS Platform VPAT 2024"
+                required
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Criteria</h2>
+          <VpatCriteriaTable criteria={criteria} onChange={setCriteria} />
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="outline" asChild>
+            <Link href={`/vpats/${vpatId}`}>Cancel</Link>
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Saving…' : 'Save Changes'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(app)/vpats/[id]/page.tsx
+++ b/src/app/(app)/vpats/[id]/page.tsx
@@ -1,0 +1,122 @@
+export const dynamic = 'force-dynamic';
+
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { ChevronLeft, Pencil } from 'lucide-react';
+import { getVpat } from '@/lib/db/vpats';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { VpatCriteriaTable } from '@/components/vpats/vpat-criteria-table';
+import { DeleteVpatButton } from '@/components/vpats/delete-vpat-button';
+import { PublishVpatButton } from '@/components/vpats/publish-vpat-button';
+import { WCAG_CRITERIA, buildDefaultCriteriaRows } from '@/lib/vpats/wcag-criteria';
+
+function getStatusBadgeClass(status: string): string {
+  return status === 'published'
+    ? 'bg-green-100 text-green-800 border-green-200'
+    : 'bg-yellow-100 text-yellow-800 border-yellow-200';
+}
+
+type PageProps = { params: Promise<{ id: string }> };
+
+export default async function VpatDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const vpat = getVpat(id);
+
+  if (!vpat) {
+    notFound();
+  }
+
+  const isPublished = vpat.status === 'published';
+
+  // Build criteria display rows: use stored criteria_rows if present, else default all to not_evaluated
+  const criteriaRows =
+    vpat.criteria_rows.length > 0
+      ? vpat.criteria_rows.map((r) => ({
+          criterion_code: r.criterion_code,
+          conformance: r.conformance,
+          remarks: r.remarks ?? '',
+          related_issue_ids: r.related_issue_ids,
+        }))
+      : buildDefaultCriteriaRows();
+
+  const scopeLabel =
+    vpat.wcag_scope.length > 0
+      ? `${vpat.wcag_scope.length} of ${WCAG_CRITERIA.length} criteria`
+      : `All ${WCAG_CRITERIA.length} criteria`;
+
+  return (
+    <div>
+      <Link
+        href="/vpats"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ChevronLeft className="h-4 w-4 mr-1" />
+        Back to VPATs
+      </Link>
+
+      <div className="flex flex-col gap-6 lg:flex-row">
+        {/* Main content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-4 mb-6">
+            <h1 className="text-2xl font-bold">{vpat.title}</h1>
+            <div className="flex items-center gap-2 shrink-0">
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/vpats/${vpat.id}/edit`}>
+                  <Pencil className="mr-2 h-4 w-4" />
+                  Edit
+                </Link>
+              </Button>
+              <PublishVpatButton vpatId={vpat.id} isPublished={isPublished} />
+              <DeleteVpatButton vpatId={vpat.id} vpatTitle={vpat.title} />
+            </div>
+          </div>
+
+          <VpatCriteriaTable criteria={criteriaRows} onChange={() => {}} readOnly />
+        </div>
+
+        {/* Sidebar */}
+        <aside className="lg:w-64 shrink-0">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                VPAT Info
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Status</span>
+                <Badge className={getStatusBadgeClass(vpat.status)} variant="outline">
+                  {vpat.status}
+                </Badge>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Version</span>
+                <span>v{vpat.version_number}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Scope</span>
+                <span className="text-right">{scopeLabel}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Created</span>
+                <span>{new Date(vpat.created_at).toLocaleDateString()}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Updated</span>
+                <span>{new Date(vpat.updated_at).toLocaleDateString()}</span>
+              </div>
+              {vpat.published_at && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Published</span>
+                  <span>{new Date(vpat.published_at).toLocaleDateString()}</span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/vpats/new/page.tsx
+++ b/src/app/(app)/vpats/new/page.tsx
@@ -8,7 +8,6 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { VpatCriteriaTable, type CriterionRow } from '@/components/vpats/vpat-criteria-table';
 import { buildDefaultCriteriaRows, CONFORMANCE_DB_VALUE } from '@/lib/vpats/wcag-criteria';
@@ -26,7 +25,6 @@ export default function NewVpatPage() {
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [projectId, setProjectId] = useState('');
-  const [notes, setNotes] = useState('');
   const [criteria, setCriteria] = useState<CriterionRow[]>(buildInitialCriteria);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -120,16 +118,6 @@ export default function NewVpatPage() {
               <p className="text-xs text-muted-foreground">
                 Find the project ID on the Projects page.
               </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="notes">Notes</Label>
-              <Textarea
-                id="notes"
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                placeholder="Optional notes about scope or evaluation methodology…"
-                rows={3}
-              />
             </div>
           </CardContent>
         </Card>

--- a/src/app/(app)/vpats/new/page.tsx
+++ b/src/app/(app)/vpats/new/page.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { VpatCriteriaTable, type CriterionRow } from '@/components/vpats/vpat-criteria-table';
+import { buildDefaultCriteriaRows, CONFORMANCE_DB_VALUE } from '@/lib/vpats/wcag-criteria';
+
+function buildInitialCriteria(): CriterionRow[] {
+  return buildDefaultCriteriaRows().map((r) => ({
+    criterion_code: r.criterion_code,
+    conformance: r.conformance,
+    remarks: '',
+    related_issue_ids: [],
+  }));
+}
+
+export default function NewVpatPage() {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [projectId, setProjectId] = useState('');
+  const [notes, setNotes] = useState('');
+  const [criteria, setCriteria] = useState<CriterionRow[]>(buildInitialCriteria);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+    if (!projectId.trim()) {
+      toast.error('Project ID is required');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const criteriaRows = criteria.map((r) => ({
+        criterion_code: r.criterion_code,
+        // Normalise: if value is already a db key keep it, else map from display label
+        conformance: (CONFORMANCE_DB_VALUE[r.conformance] ?? r.conformance) as
+          | 'supports'
+          | 'partially_supports'
+          | 'does_not_support'
+          | 'not_applicable'
+          | 'not_evaluated',
+        remarks: r.remarks ?? null,
+        related_issue_ids: r.related_issue_ids,
+      }));
+
+      const res = await fetch('/api/vpats', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          project_id: projectId.trim(),
+          wcag_scope: [],
+          criteria_rows: criteriaRows,
+        }),
+      });
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to create VPAT');
+        return;
+      }
+      toast.success('VPAT created');
+      router.push(`/vpats/${json.data.id}`);
+    } catch {
+      toast.error('Failed to create VPAT');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <Link
+        href="/vpats"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ChevronLeft className="h-4 w-4 mr-1" />
+        Back to VPATs
+      </Link>
+
+      <h1 className="text-2xl font-bold mb-6">New VPAT</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>VPAT Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="title">Title *</Label>
+              <Input
+                id="title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="e.g. Acme SaaS Platform VPAT 2024"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="projectId">Project ID *</Label>
+              <Input
+                id="projectId"
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+                placeholder="Paste a project ID"
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Find the project ID on the Projects page.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="notes">Notes</Label>
+              <Textarea
+                id="notes"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Optional notes about scope or evaluation methodology…"
+                rows={3}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Criteria</h2>
+          <VpatCriteriaTable criteria={criteria} onChange={setCriteria} />
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="outline" asChild>
+            <Link href="/vpats">Cancel</Link>
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Creating…' : 'Create VPAT'}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(app)/vpats/page.tsx
+++ b/src/app/(app)/vpats/page.tsx
@@ -1,0 +1,89 @@
+export const dynamic = 'force-dynamic';
+
+import Link from 'next/link';
+import { getVpats } from '@/lib/db/vpats';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+function getStatusBadgeClass(status: string): string {
+  return status === 'published'
+    ? 'bg-green-100 text-green-800 border-green-200'
+    : 'bg-yellow-100 text-yellow-800 border-yellow-200';
+}
+
+export default function VpatsPage() {
+  const vpats = getVpats();
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">VPATs</h1>
+        <Button asChild>
+          <Link href="/vpats/new">New VPAT</Link>
+        </Button>
+      </div>
+
+      {vpats.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-12 text-center">
+          <h2 className="text-lg font-semibold mb-2">No VPATs yet</h2>
+          <p className="text-muted-foreground mb-4">
+            Create a Voluntary Product Accessibility Template to document how your product conforms
+            to WCAG criteria.
+          </p>
+          <Button asChild>
+            <Link href="/vpats/new">Create VPAT</Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Title</TableHead>
+                <TableHead>Scope</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-20">Version</TableHead>
+                <TableHead>Updated</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {vpats.map((vpat) => (
+                <TableRow key={vpat.id}>
+                  <TableCell>
+                    <Link href={`/vpats/${vpat.id}`} className="font-medium hover:underline">
+                      {vpat.title}
+                    </Link>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {vpat.wcag_scope.length > 0
+                      ? `${vpat.wcag_scope.length} criteria`
+                      : 'All criteria'}
+                  </TableCell>
+                  <TableCell>
+                    <Badge className={getStatusBadgeClass(vpat.status)} variant="outline">
+                      {vpat.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    v{vpat.version_number}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {new Date(vpat.updated_at).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/vpats/vpat-criteria-table.test.tsx
+++ b/src/components/__tests__/vpats/vpat-criteria-table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import { VpatCriteriaTable } from '@/components/vpats/vpat-criteria-table';
 
@@ -44,4 +44,33 @@ test('renders criterion names from WCAG metadata', () => {
   render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} readOnly />);
   expect(screen.getByText('Non-text Content')).toBeInTheDocument();
   expect(screen.getByText('Keyboard')).toBeInTheDocument();
+});
+
+test('in edit mode renders select triggers with aria-labels', () => {
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} />);
+  expect(screen.getByRole('combobox', { name: 'Conformance for 1.1.1' })).toBeInTheDocument();
+  expect(screen.getByRole('combobox', { name: 'Conformance for 2.1.1' })).toBeInTheDocument();
+});
+
+test('in edit mode renders textareas with aria-labels', () => {
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} />);
+  expect(screen.getByRole('textbox', { name: 'Remarks for 1.1.1' })).toBeInTheDocument();
+  expect(screen.getByRole('textbox', { name: 'Remarks for 2.1.1' })).toBeInTheDocument();
+});
+
+test('calls onChange with db snake_case value when conformance is changed', () => {
+  const handleChange = vi.fn();
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={handleChange} />);
+
+  const select = screen.getByRole('combobox', { name: 'Conformance for 1.1.1' });
+  fireEvent.click(select);
+
+  const option = screen.getByRole('option', { name: 'Does Not Support' });
+  fireEvent.click(option);
+
+  expect(handleChange).toHaveBeenCalled();
+  const updatedCriteria: { criterion_code: string; conformance: string }[] =
+    handleChange.mock.calls[handleChange.mock.calls.length - 1][0];
+  const row = updatedCriteria.find((r) => r.criterion_code === '1.1.1');
+  expect(row?.conformance).toBe('does_not_support');
 });

--- a/src/components/__tests__/vpats/vpat-criteria-table.test.tsx
+++ b/src/components/__tests__/vpats/vpat-criteria-table.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { VpatCriteriaTable } from '@/components/vpats/vpat-criteria-table';
+
+const mockCriteria = [
+  {
+    criterion_code: '1.1.1',
+    conformance: 'supports' as const,
+    remarks: '',
+    related_issue_ids: [] as string[],
+  },
+  {
+    criterion_code: '2.1.1',
+    conformance: 'not_evaluated' as const,
+    remarks: '',
+    related_issue_ids: [] as string[],
+  },
+];
+
+test('renders criterion codes', () => {
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} readOnly />);
+  expect(screen.getByText('1.1.1')).toBeInTheDocument();
+  expect(screen.getByText('2.1.1')).toBeInTheDocument();
+});
+
+test('renders conformance display values', () => {
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} readOnly />);
+  expect(screen.getByText('Supports')).toBeInTheDocument();
+  expect(screen.getByText('Not Evaluated')).toBeInTheDocument();
+});
+
+test('in readOnly mode does not render select elements', () => {
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} readOnly />);
+  expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+});
+
+test('groups criteria by principle headings', () => {
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} readOnly />);
+  expect(screen.getByText('Perceivable')).toBeInTheDocument();
+  expect(screen.getByText('Operable')).toBeInTheDocument();
+});
+
+test('renders criterion names from WCAG metadata', () => {
+  render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} readOnly />);
+  expect(screen.getByText('Non-text Content')).toBeInTheDocument();
+  expect(screen.getByText('Keyboard')).toBeInTheDocument();
+});

--- a/src/components/__tests__/vpats/vpat-criteria-table.test.tsx
+++ b/src/components/__tests__/vpats/vpat-criteria-table.test.tsx
@@ -70,7 +70,7 @@ test('calls onChange with db snake_case value when conformance is changed', () =
 
   expect(handleChange).toHaveBeenCalled();
   const updatedCriteria: { criterion_code: string; conformance: string }[] =
-    handleChange.mock.calls[handleChange.mock.calls.length - 1][0];
-  const row = updatedCriteria.find((r) => r.criterion_code === '1.1.1');
+    handleChange.mock.calls[handleChange.mock.calls.length - 1]![0];
+  const row = updatedCriteria.find((r) => r.criterion_code === '1.1.1')!;
   expect(row?.conformance).toBe('does_not_support');
 });

--- a/src/components/vpats/delete-vpat-button.tsx
+++ b/src/components/vpats/delete-vpat-button.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteVpatButtonProps {
+  vpatId: string;
+  vpatTitle: string;
+}
+
+export function DeleteVpatButton({ vpatId, vpatTitle }: DeleteVpatButtonProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/vpats/${vpatId}`, { method: 'DELETE' });
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to delete VPAT');
+        return;
+      }
+      toast.success('VPAT deleted');
+      router.push('/vpats');
+      router.refresh();
+    } catch {
+      toast.error('Failed to delete VPAT');
+    } finally {
+      setIsDeleting(false);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" size="sm">
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete VPAT</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete &ldquo;{vpatTitle}&rdquo;? This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/vpats/publish-vpat-button.tsx
+++ b/src/components/vpats/publish-vpat-button.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface PublishVpatButtonProps {
+  vpatId: string;
+  isPublished: boolean;
+}
+
+export function PublishVpatButton({ vpatId, isPublished }: PublishVpatButtonProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handlePublish() {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/vpats/${vpatId}/publish`, { method: 'POST' });
+      const json = await res.json();
+      if (!json.success) {
+        toast.error(json.error ?? 'Failed to publish VPAT');
+        return;
+      }
+      toast.success(isPublished ? 'VPAT re-published' : 'VPAT published');
+      router.refresh();
+    } catch {
+      toast.error('Failed to publish VPAT');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Button variant="default" size="sm" onClick={handlePublish} disabled={isLoading}>
+      <Send className="mr-2 h-4 w-4" />
+      {isLoading ? 'Publishing…' : isPublished ? 'Re-publish' : 'Publish'}
+    </Button>
+  );
+}

--- a/src/components/vpats/vpat-criteria-table.tsx
+++ b/src/components/vpats/vpat-criteria-table.tsx
@@ -76,9 +76,8 @@ export function VpatCriteriaTable({
                   const meta = WCAG_CRITERIA.find((c) => c.criterion === row.criterion_code);
                   // Display value: convert db snake_case to human-readable label
                   const displayConformance =
-                    CONFORMANCE_DISPLAY[row.conformance] ?? row.conformance;
-                  // Select value: use display label so SelectItem values match
-                  const selectValue = CONFORMANCE_DISPLAY[row.conformance] ?? row.conformance;
+                    CONFORMANCE_DISPLAY[row.conformance as keyof typeof CONFORMANCE_DISPLAY] ??
+                    row.conformance;
 
                   return (
                     <TableRow key={row.criterion_code}>
@@ -92,7 +91,7 @@ export function VpatCriteriaTable({
                           <span className="text-sm">{displayConformance}</span>
                         ) : (
                           <Select
-                            value={selectValue}
+                            value={displayConformance}
                             onValueChange={(v) =>
                               updateRow(
                                 row.criterion_code,
@@ -101,7 +100,10 @@ export function VpatCriteriaTable({
                               )
                             }
                           >
-                            <SelectTrigger className="h-8 text-sm">
+                            <SelectTrigger
+                              className="h-8 text-sm"
+                              aria-label={`Conformance for ${row.criterion_code}`}
+                            >
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
@@ -128,6 +130,7 @@ export function VpatCriteriaTable({
                             rows={2}
                             className="text-sm min-h-0"
                             placeholder="Add remarks…"
+                            aria-label={`Remarks for ${row.criterion_code}`}
                           />
                         )}
                       </TableCell>

--- a/src/components/vpats/vpat-criteria-table.tsx
+++ b/src/components/vpats/vpat-criteria-table.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  WCAG_CRITERIA,
+  CONFORMANCE_OPTIONS,
+  CONFORMANCE_DISPLAY,
+  CONFORMANCE_DB_VALUE,
+} from '@/lib/vpats/wcag-criteria';
+
+export interface CriterionRow {
+  criterion_code: string;
+  conformance: string;
+  remarks: string | null | undefined;
+  related_issue_ids: string[];
+}
+
+interface VpatCriteriaTableProps {
+  criteria: CriterionRow[];
+  onChange: (criteria: CriterionRow[]) => void;
+  readOnly?: boolean;
+}
+
+const PRINCIPLES = ['Perceivable', 'Operable', 'Understandable', 'Robust'] as const;
+
+export function VpatCriteriaTable({
+  criteria,
+  onChange,
+  readOnly = false,
+}: VpatCriteriaTableProps) {
+  const updateRow = (criterion_code: string, field: keyof CriterionRow, value: string) => {
+    onChange(
+      criteria.map((r) => (r.criterion_code === criterion_code ? { ...r, [field]: value } : r))
+    );
+  };
+
+  return (
+    <div className="space-y-8">
+      {PRINCIPLES.map((principle) => {
+        const rows = criteria.filter((r) => {
+          const meta = WCAG_CRITERIA.find((c) => c.criterion === r.criterion_code);
+          return meta?.principle === principle;
+        });
+        if (rows.length === 0) return null;
+
+        return (
+          <div key={principle}>
+            <h3 className="text-lg font-semibold mb-2">{principle}</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-24">Criterion</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead className="w-16">Level</TableHead>
+                  <TableHead className="w-48">Conformance</TableHead>
+                  <TableHead>Remarks</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => {
+                  const meta = WCAG_CRITERIA.find((c) => c.criterion === row.criterion_code);
+                  // Display value: convert db snake_case to human-readable label
+                  const displayConformance =
+                    CONFORMANCE_DISPLAY[row.conformance] ?? row.conformance;
+                  // Select value: use display label so SelectItem values match
+                  const selectValue = CONFORMANCE_DISPLAY[row.conformance] ?? row.conformance;
+
+                  return (
+                    <TableRow key={row.criterion_code}>
+                      <TableCell className="font-mono text-sm">{row.criterion_code}</TableCell>
+                      <TableCell>{meta?.name ?? row.criterion_code}</TableCell>
+                      <TableCell>
+                        <span className="text-xs font-medium">{meta?.level ?? ''}</span>
+                      </TableCell>
+                      <TableCell>
+                        {readOnly ? (
+                          <span className="text-sm">{displayConformance}</span>
+                        ) : (
+                          <Select
+                            value={selectValue}
+                            onValueChange={(v) =>
+                              updateRow(
+                                row.criterion_code,
+                                'conformance',
+                                CONFORMANCE_DB_VALUE[v] ?? v
+                              )
+                            }
+                          >
+                            <SelectTrigger className="h-8 text-sm">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {CONFORMANCE_OPTIONS.map((opt) => (
+                                <SelectItem key={opt} value={opt}>
+                                  {opt}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {readOnly ? (
+                          <span className="text-sm text-muted-foreground">
+                            {row.remarks || '—'}
+                          </span>
+                        ) : (
+                          <Textarea
+                            value={row.remarks ?? ''}
+                            onChange={(e) =>
+                              updateRow(row.criterion_code, 'remarks', e.target.value)
+                            }
+                            rows={2}
+                            className="text-sm min-h-0"
+                            placeholder="Add remarks…"
+                          />
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/db/__tests__/vpats.test.ts
+++ b/src/lib/db/__tests__/vpats.test.ts
@@ -10,6 +10,7 @@ import {
   deleteVpat,
   publishVpat,
   getInvalidIssueIds,
+  safeParse,
 } from '../vpats';
 
 let projectId: string;
@@ -236,5 +237,41 @@ describe('getInvalidIssueIds', () => {
     const invalid = getInvalidIssueIds(['nonexistent-id-1', 'nonexistent-id-2']);
     expect(invalid).toContain('nonexistent-id-1');
     expect(invalid).toContain('nonexistent-id-2');
+  });
+});
+
+describe('safeParse', () => {
+  it('parses valid JSON and returns the value', () => {
+    expect(safeParse('["1.1.1","4.1.2"]', [])).toEqual(['1.1.1', '4.1.2']);
+  });
+
+  it('returns the fallback for malformed JSON', () => {
+    expect(safeParse('not valid json{{', [])).toEqual([]);
+  });
+
+  it('returns the fallback for empty string', () => {
+    expect(safeParse('', [])).toEqual([]);
+  });
+
+  it('returns the fallback for null-ish values', () => {
+    expect(safeParse(undefined as unknown as string, [])).toEqual([]);
+  });
+
+  it('does not throw when getVpat encounters corrupt wcag_scope', () => {
+    const vpat = createVpat({ title: 'VPAT', project_id: projectId });
+    // Manually corrupt the wcag_scope column in the DB
+    getDb().prepare("UPDATE vpats SET wcag_scope = 'CORRUPT{{' WHERE id = ?").run(vpat.id);
+    expect(() => getVpat(vpat.id)).not.toThrow();
+    const found = getVpat(vpat.id);
+    expect(found).not.toBeNull();
+    expect(found!.wcag_scope).toEqual([]);
+  });
+
+  it('does not throw when getVpats encounters corrupt criteria_rows', () => {
+    const vpat = createVpat({ title: 'VPAT', project_id: projectId });
+    getDb().prepare("UPDATE vpats SET criteria_rows = 'CORRUPT{{' WHERE id = ?").run(vpat.id);
+    expect(() => getVpats(projectId)).not.toThrow();
+    const results = getVpats(projectId);
+    expect(results[0]!.criteria_rows).toEqual([]);
   });
 });

--- a/src/lib/db/vpats.ts
+++ b/src/lib/db/vpats.ts
@@ -32,12 +32,20 @@ interface VpatRow {
   updated_at: string;
 }
 
+export function safeParse<T>(json: string, fallback: T): T {
+  try {
+    return JSON.parse(json || JSON.stringify(fallback));
+  } catch {
+    return fallback;
+  }
+}
+
 function parseVpat(raw: VpatRow): Vpat {
   return {
     ...raw,
     status: raw.status as Vpat['status'],
-    wcag_scope: JSON.parse(raw.wcag_scope || '[]'),
-    criteria_rows: JSON.parse(raw.criteria_rows || '[]'),
+    wcag_scope: safeParse(raw.wcag_scope, []),
+    criteria_rows: safeParse(raw.criteria_rows, []),
   };
 }
 

--- a/src/lib/vpats/wcag-criteria.ts
+++ b/src/lib/vpats/wcag-criteria.ts
@@ -46,8 +46,15 @@ export const CONFORMANCE_OPTIONS = [
 
 export type ConformanceLevel = (typeof CONFORMANCE_OPTIONS)[number];
 
+type DbConformance =
+  | 'supports'
+  | 'partially_supports'
+  | 'does_not_support'
+  | 'not_applicable'
+  | 'not_evaluated';
+
 // Map from DB snake_case conformance values to display labels
-export const CONFORMANCE_DISPLAY: Record<string, string> = {
+export const CONFORMANCE_DISPLAY: Record<DbConformance, string> = {
   supports: 'Supports',
   partially_supports: 'Partially Supports',
   does_not_support: 'Does Not Support',
@@ -56,7 +63,7 @@ export const CONFORMANCE_DISPLAY: Record<string, string> = {
 };
 
 // Map from display labels to DB snake_case values
-export const CONFORMANCE_DB_VALUE: Record<string, string> = {
+export const CONFORMANCE_DB_VALUE: Record<string, DbConformance> = {
   Supports: 'supports',
   'Partially Supports': 'partially_supports',
   'Does Not Support': 'does_not_support',

--- a/src/lib/vpats/wcag-criteria.ts
+++ b/src/lib/vpats/wcag-criteria.ts
@@ -1,0 +1,75 @@
+// WCAG criteria metadata used by VPAT UI components.
+// criterion_code values must match those in src/lib/constants/wcag.ts
+
+export const WCAG_CRITERIA = [
+  // Perceivable
+  { criterion: '1.1.1', name: 'Non-text Content', level: 'A', principle: 'Perceivable' },
+  {
+    criterion: '1.2.1',
+    name: 'Audio-only and Video-only (Prerecorded)',
+    level: 'A',
+    principle: 'Perceivable',
+  },
+  { criterion: '1.2.2', name: 'Captions (Prerecorded)', level: 'A', principle: 'Perceivable' },
+  { criterion: '1.3.1', name: 'Info and Relationships', level: 'A', principle: 'Perceivable' },
+  { criterion: '1.3.2', name: 'Meaningful Sequence', level: 'A', principle: 'Perceivable' },
+  { criterion: '1.4.1', name: 'Use of Color', level: 'A', principle: 'Perceivable' },
+  { criterion: '1.4.3', name: 'Contrast (Minimum)', level: 'AA', principle: 'Perceivable' },
+  { criterion: '1.4.4', name: 'Resize Text', level: 'AA', principle: 'Perceivable' },
+  { criterion: '1.4.11', name: 'Non-text Contrast', level: 'AA', principle: 'Perceivable' },
+  // Operable
+  { criterion: '2.1.1', name: 'Keyboard', level: 'A', principle: 'Operable' },
+  { criterion: '2.1.2', name: 'No Keyboard Trap', level: 'A', principle: 'Operable' },
+  { criterion: '2.2.2', name: 'Pause, Stop, Hide', level: 'A', principle: 'Operable' },
+  { criterion: '2.4.1', name: 'Bypass Blocks', level: 'A', principle: 'Operable' },
+  { criterion: '2.4.3', name: 'Focus Order', level: 'A', principle: 'Operable' },
+  { criterion: '2.4.7', name: 'Focus Visible', level: 'AA', principle: 'Operable' },
+  { criterion: '2.5.3', name: 'Label in Name', level: 'A', principle: 'Operable' },
+  // Understandable
+  { criterion: '3.1.1', name: 'Language of Page', level: 'A', principle: 'Understandable' },
+  { criterion: '3.2.1', name: 'On Focus', level: 'A', principle: 'Understandable' },
+  { criterion: '3.3.1', name: 'Error Identification', level: 'A', principle: 'Understandable' },
+  { criterion: '3.3.2', name: 'Labels or Instructions', level: 'A', principle: 'Understandable' },
+  { criterion: '3.3.3', name: 'Error Suggestion', level: 'AA', principle: 'Understandable' },
+  // Robust
+  { criterion: '4.1.2', name: 'Name, Role, Value', level: 'A', principle: 'Robust' },
+  { criterion: '4.1.3', name: 'Status Messages', level: 'AA', principle: 'Robust' },
+] as const;
+
+export const CONFORMANCE_OPTIONS = [
+  'Supports',
+  'Partially Supports',
+  'Does Not Support',
+  'Not Applicable',
+  'Not Evaluated',
+] as const;
+
+export type ConformanceLevel = (typeof CONFORMANCE_OPTIONS)[number];
+
+// Map from DB snake_case conformance values to display labels
+export const CONFORMANCE_DISPLAY: Record<string, string> = {
+  supports: 'Supports',
+  partially_supports: 'Partially Supports',
+  does_not_support: 'Does Not Support',
+  not_applicable: 'Not Applicable',
+  not_evaluated: 'Not Evaluated',
+};
+
+// Map from display labels to DB snake_case values
+export const CONFORMANCE_DB_VALUE: Record<string, string> = {
+  Supports: 'supports',
+  'Partially Supports': 'partially_supports',
+  'Does Not Support': 'does_not_support',
+  'Not Applicable': 'not_applicable',
+  'Not Evaluated': 'not_evaluated',
+};
+
+/** Build default criteria_rows for all WCAG criteria, all set to not_evaluated. */
+export function buildDefaultCriteriaRows() {
+  return WCAG_CRITERIA.map((c) => ({
+    criterion_code: c.criterion,
+    conformance: 'not_evaluated' as const,
+    remarks: '',
+    related_issue_ids: [] as string[],
+  }));
+}


### PR DESCRIPTION
## Summary
- VPATs list/detail/create/edit pages under `/vpats`
- `VpatCriteriaTable` with per-criterion conformance Select and remarks Textarea
- WCAG criterion codes validated against canonical list
- Accessible selects with `aria-label` per criterion

## Test Plan
- [ ] Unit tests: 38 files, 421 tests passing
- [ ] Lint, type-check, format all clean
- [ ] Create VPAT → set conformance levels → save