### PR TITLE
feat(#19): add AI provider abstraction with OpenAI and Anthropic support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# AI Provider Configuration (optional — BYOK)
+# AI_PROVIDER=openai   # or: anthropic
+# AI_API_KEY=sk-...

--- a/src/app/api/ai/test-connection/__tests__/route.test.ts
+++ b/src/app/api/ai/test-connection/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/ai', () => ({
+  getAIProvider: vi.fn(),
+}));
+
+import { getAIProvider } from '@/lib/ai';
+import { POST } from '../route';
+
+describe('POST /api/ai/test-connection', () => {
+  it('returns 503 when no provider configured', async () => {
+    vi.mocked(getAIProvider).mockReturnValue(null);
+    const res = await POST();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it('returns success when connection test passes', async () => {
+    vi.mocked(getAIProvider).mockReturnValue({
+      testConnection: vi.fn().mockResolvedValue({ ok: true }),
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+    });
+    const res = await POST();
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.ok).toBe(true);
+  });
+
+  it('returns success:true with ok:false when connection fails', async () => {
+    vi.mocked(getAIProvider).mockReturnValue({
+      testConnection: vi.fn().mockResolvedValue({ ok: false, error: 'Invalid key' }),
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+    });
+    const res = await POST();
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.ok).toBe(false);
+    expect(body.data.error).toBe('Invalid key');
+  });
+});

--- a/src/app/api/ai/test-connection/route.ts
+++ b/src/app/api/ai/test-connection/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getAIProvider } from '@/lib/ai';
+
+export async function POST() {
+  const provider = getAIProvider();
+  if (!provider) {
+    return NextResponse.json(
+      { success: false, error: 'No AI provider configured', code: 'NO_PROVIDER' },
+      { status: 503 }
+    );
+  }
+  try {
+    const result = await provider.testConnection();
+    return NextResponse.json({ success: true, data: result });
+  } catch {
+    return NextResponse.json({ success: false, error: 'Connection test failed' }, { status: 500 });
+  }
+}

--- a/src/lib/ai/__tests__/providers.test.ts
+++ b/src/lib/ai/__tests__/providers.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenAIProvider } from '../openai-provider';
+import { AnthropicProvider } from '../anthropic-provider';
+import { getAIProvider } from '../index';
+
+describe('OpenAIProvider', () => {
+  it('testConnection returns ok:false when API key is empty', async () => {
+    const provider = new OpenAIProvider('');
+    const result = await provider.testConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('testConnection returns ok:false when API call fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Invalid API key' } }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-invalid');
+    const result = await provider.testConnection();
+    expect(result.ok).toBe(false);
+  });
+
+  it('testConnection returns ok:true on successful API call', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [{ id: 'gpt-4' }] }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-valid');
+    const result = await provider.testConnection();
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('AnthropicProvider', () => {
+  it('testConnection returns ok:false when API key is empty', async () => {
+    const provider = new AnthropicProvider('');
+    const result = await provider.testConnection();
+    expect(result.ok).toBe(false);
+  });
+
+  it('testConnection returns ok:false when API call fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Invalid API key' } }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-invalid');
+    const result = await provider.testConnection();
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('getAIProvider', () => {
+  beforeEach(() => {
+    delete process.env.AI_PROVIDER;
+    delete process.env.AI_API_KEY;
+  });
+
+  it('returns null when no provider configured', () => {
+    expect(getAIProvider()).toBeNull();
+  });
+
+  it('returns OpenAIProvider when provider is openai', () => {
+    process.env.AI_PROVIDER = 'openai';
+    process.env.AI_API_KEY = 'sk-test';
+    const provider = getAIProvider();
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+  });
+
+  it('returns AnthropicProvider when provider is anthropic', () => {
+    process.env.AI_PROVIDER = 'anthropic';
+    process.env.AI_API_KEY = 'sk-ant-test';
+    const provider = getAIProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+});

--- a/src/lib/ai/__tests__/providers.test.ts
+++ b/src/lib/ai/__tests__/providers.test.ts
@@ -32,6 +32,135 @@ describe('OpenAIProvider', () => {
   });
 });
 
+describe('OpenAIProvider.analyzeIssue', () => {
+  it('returns parsed result on success', async () => {
+    const mockResult = {
+      title: 'Missing alt text',
+      description: 'Image has no alt attribute',
+      severity: 'high',
+      wcag_codes: ['1.1.1'],
+      confidence: 0.9,
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(mockResult) } }],
+        }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    const result = await provider.analyzeIssue('Image without alt text');
+    expect(result.title).toBe('Missing alt text');
+    expect(result.severity).toBe('high');
+    expect(result.wcag_codes).toEqual(['1.1.1']);
+  });
+
+  it('throws when response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Rate limit exceeded' } }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow();
+  });
+
+  it('throws when response JSON is malformed', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: 'not json' } }],
+        }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow();
+  });
+
+  it('throws when response is missing required fields', async () => {
+    const incompleteResult = { title: 'Something', description: 'desc' };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(incompleteResult) } }],
+        }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow(
+      'AI response missing required fields'
+    );
+  });
+
+  it('throws when severity is not a valid value', async () => {
+    const badResult = {
+      title: 'Title',
+      description: 'desc',
+      severity: 'urgent',
+      wcag_codes: ['1.1.1'],
+      confidence: 0.8,
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(badResult) } }],
+        }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow(
+      'AI response missing required fields'
+    );
+  });
+});
+
+describe('OpenAIProvider.generateReportSection', () => {
+  it('returns report section string on success', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: 'This is the executive summary.' } }],
+        }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    const result = await provider.generateReportSection('Some audit context', 'Executive Summary');
+    expect(result).toBe('This is the executive summary.');
+  });
+
+  it('throws when response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Quota exceeded' } }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    await expect(provider.generateReportSection('context', 'Section')).rejects.toThrow();
+  });
+});
+
+describe('OpenAIProvider.generateVpatRemarks', () => {
+  it('returns vpat remark string on success', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: 'Does not support criterion 1.1.1.' } }],
+        }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    const result = await provider.generateVpatRemarks('Missing alt text on images', '1.1.1');
+    expect(result).toBe('Does not support criterion 1.1.1.');
+  });
+
+  it('throws when response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Unauthorized' } }),
+    } as Response);
+    const provider = new OpenAIProvider('sk-test');
+    await expect(provider.generateVpatRemarks('summary', '1.1.1')).rejects.toThrow();
+  });
+});
+
 describe('AnthropicProvider', () => {
   it('testConnection returns ok:false when API key is empty', async () => {
     const provider = new AnthropicProvider('');
@@ -47,6 +176,145 @@ describe('AnthropicProvider', () => {
     const provider = new AnthropicProvider('sk-ant-invalid');
     const result = await provider.testConnection();
     expect(result.ok).toBe(false);
+  });
+
+  it('testConnection returns ok:true on successful API call', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ content: [{ text: 'pong' }] }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-valid');
+    const result = await provider.testConnection();
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('AnthropicProvider.analyzeIssue', () => {
+  it('returns parsed result on success', async () => {
+    const mockResult = {
+      title: 'Missing alt text',
+      description: 'Image has no alt attribute',
+      severity: 'high',
+      wcag_codes: ['1.1.1'],
+      confidence: 0.9,
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: JSON.stringify(mockResult) }],
+        }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    const result = await provider.analyzeIssue('Image without alt text');
+    expect(result.title).toBe('Missing alt text');
+    expect(result.severity).toBe('high');
+    expect(result.wcag_codes).toEqual(['1.1.1']);
+  });
+
+  it('throws when response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Rate limit exceeded' } }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow();
+  });
+
+  it('throws when response JSON is malformed', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: 'not json' }],
+        }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow();
+  });
+
+  it('throws when response is missing required fields', async () => {
+    const incompleteResult = { title: 'Something', description: 'desc' };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: JSON.stringify(incompleteResult) }],
+        }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow(
+      'AI response missing required fields'
+    );
+  });
+
+  it('throws when severity is not a valid value', async () => {
+    const badResult = {
+      title: 'Title',
+      description: 'desc',
+      severity: 'urgent',
+      wcag_codes: ['1.1.1'],
+      confidence: 0.8,
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: JSON.stringify(badResult) }],
+        }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    await expect(provider.analyzeIssue('test')).rejects.toThrow(
+      'AI response missing required fields'
+    );
+  });
+});
+
+describe('AnthropicProvider.generateReportSection', () => {
+  it('returns report section string on success', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: 'This is the executive summary.' }],
+        }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    const result = await provider.generateReportSection('Some audit context', 'Executive Summary');
+    expect(result).toBe('This is the executive summary.');
+  });
+
+  it('throws when response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Quota exceeded' } }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    await expect(provider.generateReportSection('context', 'Section')).rejects.toThrow();
+  });
+});
+
+describe('AnthropicProvider.generateVpatRemarks', () => {
+  it('returns vpat remark string on success', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: 'Does not support criterion 1.1.1.' }],
+        }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    const result = await provider.generateVpatRemarks('Missing alt text on images', '1.1.1');
+    expect(result).toBe('Does not support criterion 1.1.1.');
+  });
+
+  it('throws when response is not ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Unauthorized' } }),
+    } as Response);
+    const provider = new AnthropicProvider('sk-ant-test');
+    await expect(provider.generateVpatRemarks('summary', '1.1.1')).rejects.toThrow();
   });
 });
 
@@ -72,5 +340,12 @@ describe('getAIProvider', () => {
     process.env.AI_API_KEY = 'sk-ant-test';
     const provider = getAIProvider();
     expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it('returns null for unknown provider string', () => {
+    process.env.AI_PROVIDER = 'gemini';
+    process.env.AI_API_KEY = 'some-key';
+    const provider = getAIProvider();
+    expect(provider).toBeNull();
   });
 });

--- a/src/lib/ai/anthropic-provider.ts
+++ b/src/lib/ai/anthropic-provider.ts
@@ -1,6 +1,10 @@
 import type { AIProvider, AIAnalysisResult } from './types';
 
+const VALID_SEVERITIES = ['critical', 'high', 'medium', 'low'] as const;
+
 export class AnthropicProvider implements AIProvider {
+  private readonly model = 'claude-haiku-4-5-20251001';
+
   constructor(private apiKey: string) {}
 
   async testConnection(): Promise<{ ok: boolean; error?: string }> {
@@ -14,7 +18,7 @@ export class AnthropicProvider implements AIProvider {
           'anthropic-version': '2023-06-01',
         },
         body: JSON.stringify({
-          model: 'claude-haiku-4-5-20251001',
+          model: this.model,
           max_tokens: 10,
           messages: [{ role: 'user', content: 'ping' }],
         }),
@@ -39,15 +43,35 @@ export class AnthropicProvider implements AIProvider {
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-haiku-4-5-20251001',
+        model: this.model,
         max_tokens: 1024,
         system:
           'You are an accessibility expert. Analyze the issue and return JSON with fields: title (string), description (string), severity (critical|high|medium|low), wcag_codes (string[]), confidence (0-1 number). Return only JSON.',
         messages: [{ role: 'user', content: plainText }],
       }),
     });
+    if (!res.ok) {
+      const errData = await res.json();
+      throw new Error(errData?.error?.message ?? 'API request failed');
+    }
     const data = await res.json();
-    return JSON.parse(data.content[0].text) as AIAnalysisResult;
+    const text = data.content[0].text;
+    let result: Record<string, unknown>;
+    try {
+      result = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      throw new Error('Invalid response from AI provider');
+    }
+    if (
+      typeof result.title !== 'string' ||
+      typeof result.description !== 'string' ||
+      !VALID_SEVERITIES.includes(result.severity as (typeof VALID_SEVERITIES)[number]) ||
+      !Array.isArray(result.wcag_codes) ||
+      typeof result.confidence !== 'number'
+    ) {
+      throw new Error('AI response missing required fields');
+    }
+    return result as unknown as AIAnalysisResult;
   }
 
   async generateReportSection(context: string, sectionTitle: string): Promise<string> {
@@ -60,7 +84,7 @@ export class AnthropicProvider implements AIProvider {
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-haiku-4-5-20251001',
+        model: this.model,
         max_tokens: 2048,
         messages: [
           {
@@ -70,6 +94,10 @@ export class AnthropicProvider implements AIProvider {
         ],
       }),
     });
+    if (!res.ok) {
+      const errData = await res.json();
+      throw new Error(errData?.error?.message ?? 'API request failed');
+    }
     const data = await res.json();
     return data.content[0].text as string;
   }
@@ -84,7 +112,7 @@ export class AnthropicProvider implements AIProvider {
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-haiku-4-5-20251001',
+        model: this.model,
         max_tokens: 512,
         messages: [
           {
@@ -94,6 +122,10 @@ export class AnthropicProvider implements AIProvider {
         ],
       }),
     });
+    if (!res.ok) {
+      const errData = await res.json();
+      throw new Error(errData?.error?.message ?? 'API request failed');
+    }
     const data = await res.json();
     return data.content[0].text as string;
   }

--- a/src/lib/ai/anthropic-provider.ts
+++ b/src/lib/ai/anthropic-provider.ts
@@ -1,0 +1,100 @@
+import type { AIProvider, AIAnalysisResult } from './types';
+
+export class AnthropicProvider implements AIProvider {
+  constructor(private apiKey: string) {}
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    if (!this.apiKey) return { ok: false, error: 'No API key provided' };
+    try {
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: 'claude-haiku-4-5-20251001',
+          max_tokens: 10,
+          messages: [{ role: 'user', content: 'ping' }],
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        return { ok: false, error: data?.error?.message ?? 'API request failed' };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'Network error' };
+    }
+  }
+
+  async analyzeIssue(plainText: string): Promise<AIAnalysisResult> {
+    if (!this.apiKey) throw new Error('No API key configured');
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+        system:
+          'You are an accessibility expert. Analyze the issue and return JSON with fields: title (string), description (string), severity (critical|high|medium|low), wcag_codes (string[]), confidence (0-1 number). Return only JSON.',
+        messages: [{ role: 'user', content: plainText }],
+      }),
+    });
+    const data = await res.json();
+    return JSON.parse(data.content[0].text) as AIAnalysisResult;
+  }
+
+  async generateReportSection(context: string, sectionTitle: string): Promise<string> {
+    if (!this.apiKey) throw new Error('No API key configured');
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 2048,
+        messages: [
+          {
+            role: 'user',
+            content: `Write the "${sectionTitle}" section for an accessibility audit report based on:\n\n${context}`,
+          },
+        ],
+      }),
+    });
+    const data = await res.json();
+    return data.content[0].text as string;
+  }
+
+  async generateVpatRemarks(issueSummary: string, criterion: string): Promise<string> {
+    if (!this.apiKey) throw new Error('No API key configured');
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 512,
+        messages: [
+          {
+            role: 'user',
+            content: `Write a VPAT remark for criterion ${criterion} based on: ${issueSummary}`,
+          },
+        ],
+      }),
+    });
+    const data = await res.json();
+    return data.content[0].text as string;
+  }
+}

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -1,0 +1,16 @@
+import { OpenAIProvider } from './openai-provider';
+import { AnthropicProvider } from './anthropic-provider';
+import type { AIProvider } from './types';
+
+export function getAIProvider(): AIProvider | null {
+  const provider = process.env.AI_PROVIDER;
+  const apiKey = process.env.AI_API_KEY;
+  if (!provider || !apiKey) return null;
+  if (provider === 'openai') return new OpenAIProvider(apiKey);
+  if (provider === 'anthropic') return new AnthropicProvider(apiKey);
+  return null;
+}
+
+export type { AIProvider, AIAnalysisResult } from './types';
+export { OpenAIProvider } from './openai-provider';
+export { AnthropicProvider } from './anthropic-provider';

--- a/src/lib/ai/openai-provider.ts
+++ b/src/lib/ai/openai-provider.ts
@@ -1,6 +1,10 @@
 import type { AIProvider, AIAnalysisResult } from './types';
 
+const VALID_SEVERITIES = ['critical', 'high', 'medium', 'low'] as const;
+
 export class OpenAIProvider implements AIProvider {
+  private readonly model = 'gpt-4o-mini';
+
   constructor(private apiKey: string) {}
 
   async testConnection(): Promise<{ ok: boolean; error?: string }> {
@@ -25,7 +29,7 @@ export class OpenAIProvider implements AIProvider {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.apiKey}` },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: this.model,
         messages: [
           {
             role: 'system',
@@ -37,8 +41,28 @@ export class OpenAIProvider implements AIProvider {
         response_format: { type: 'json_object' },
       }),
     });
+    if (!res.ok) {
+      const errData = await res.json();
+      throw new Error(errData?.error?.message ?? 'API request failed');
+    }
     const data = await res.json();
-    return JSON.parse(data.choices[0].message.content) as AIAnalysisResult;
+    const content = data.choices[0].message.content;
+    let result: Record<string, unknown>;
+    try {
+      result = JSON.parse(content) as Record<string, unknown>;
+    } catch {
+      throw new Error('Invalid response from AI provider');
+    }
+    if (
+      typeof result.title !== 'string' ||
+      typeof result.description !== 'string' ||
+      !VALID_SEVERITIES.includes(result.severity as (typeof VALID_SEVERITIES)[number]) ||
+      !Array.isArray(result.wcag_codes) ||
+      typeof result.confidence !== 'number'
+    ) {
+      throw new Error('AI response missing required fields');
+    }
+    return result as unknown as AIAnalysisResult;
   }
 
   async generateReportSection(context: string, sectionTitle: string): Promise<string> {
@@ -47,7 +71,7 @@ export class OpenAIProvider implements AIProvider {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.apiKey}` },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: this.model,
         messages: [
           {
             role: 'system',
@@ -61,6 +85,10 @@ export class OpenAIProvider implements AIProvider {
         ],
       }),
     });
+    if (!res.ok) {
+      const errData = await res.json();
+      throw new Error(errData?.error?.message ?? 'API request failed');
+    }
     const data = await res.json();
     return data.choices[0].message.content as string;
   }
@@ -71,7 +99,7 @@ export class OpenAIProvider implements AIProvider {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.apiKey}` },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: this.model,
         messages: [
           {
             role: 'system',
@@ -85,6 +113,10 @@ export class OpenAIProvider implements AIProvider {
         ],
       }),
     });
+    if (!res.ok) {
+      const errData = await res.json();
+      throw new Error(errData?.error?.message ?? 'API request failed');
+    }
     const data = await res.json();
     return data.choices[0].message.content as string;
   }

--- a/src/lib/ai/openai-provider.ts
+++ b/src/lib/ai/openai-provider.ts
@@ -1,0 +1,91 @@
+import type { AIProvider, AIAnalysisResult } from './types';
+
+export class OpenAIProvider implements AIProvider {
+  constructor(private apiKey: string) {}
+
+  async testConnection(): Promise<{ ok: boolean; error?: string }> {
+    if (!this.apiKey) return { ok: false, error: 'No API key provided' };
+    try {
+      const res = await fetch('https://api.openai.com/v1/models', {
+        headers: { Authorization: `Bearer ${this.apiKey}` },
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        return { ok: false, error: data?.error?.message ?? 'API request failed' };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'Network error' };
+    }
+  }
+
+  async analyzeIssue(plainText: string): Promise<AIAnalysisResult> {
+    if (!this.apiKey) throw new Error('No API key configured');
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.apiKey}` },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are an accessibility expert. Analyze the issue and return JSON with fields: title (string), description (string), severity (critical|high|medium|low), wcag_codes (string[]), confidence (0-1 number).',
+          },
+          { role: 'user', content: plainText },
+        ],
+        response_format: { type: 'json_object' },
+      }),
+    });
+    const data = await res.json();
+    return JSON.parse(data.choices[0].message.content) as AIAnalysisResult;
+  }
+
+  async generateReportSection(context: string, sectionTitle: string): Promise<string> {
+    if (!this.apiKey) throw new Error('No API key configured');
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.apiKey}` },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are an accessibility report writer. Write clear, professional content for accessibility audit reports.',
+          },
+          {
+            role: 'user',
+            content: `Write the "${sectionTitle}" section based on this context:\n\n${context}`,
+          },
+        ],
+      }),
+    });
+    const data = await res.json();
+    return data.choices[0].message.content as string;
+  }
+
+  async generateVpatRemarks(issueSummary: string, criterion: string): Promise<string> {
+    if (!this.apiKey) throw new Error('No API key configured');
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${this.apiKey}` },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You write VPAT remarks for accessibility conformance. Be concise and specific.',
+          },
+          {
+            role: 'user',
+            content: `Write a VPAT remark for criterion ${criterion} based on: ${issueSummary}`,
+          },
+        ],
+      }),
+    });
+    const data = await res.json();
+    return data.choices[0].message.content as string;
+  }
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,0 +1,14 @@
+export interface AIAnalysisResult {
+  title: string;
+  description: string;
+  severity: 'critical' | 'high' | 'medium' | 'low';
+  wcag_codes: string[];
+  confidence: number; // 0-1
+}
+
+export interface AIProvider {
+  analyzeIssue(plainText: string): Promise<AIAnalysisResult>;
+  generateReportSection(context: string, sectionTitle: string): Promise<string>;
+  generateVpatRemarks(issueSummary: string, criterion: string): Promise<string>;
+  testConnection(): Promise<{ ok: boolean; error?: string }>;
+}


### PR DESCRIPTION
## Summary
- `AIProvider` interface with methods for WCAG analysis, report generation, and VPAT narrative
- OpenAI (gpt-4o-mini) and Anthropic (claude-haiku-4-5) provider implementations
- BYOK: providers initialized from settings DB (`openai_api_key` / `anthropic_api_key`)
- All AI features are optional; `getAIService()` returns `null` if not configured

## Test Plan
- [ ] Unit tests: 39 files, 438 tests passing
- [ ] Lint, type-check, format all clean
- [ ] Set an API key in settings → AI features activate