### PR TITLE
feat(#20): add AI assist UI for WCAG suggestions, report summaries, and VPAT narratives

### DIFF
--- a/src/app/api/ai/generate-report-summary/__tests__/route.test.ts
+++ b/src/app/api/ai/generate-report-summary/__tests__/route.test.ts
@@ -122,6 +122,36 @@ describe('POST /api/ai/generate-report-summary', () => {
     expect(mockGenerate).toHaveBeenCalledWith(expect.any(String), 'Executive Summary');
   });
 
+  it('returns 404 when report belongs to a different project', async () => {
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const project1 = createProject({ name: 'Project 1' });
+    const project2 = createProject({ name: 'Project 2' });
+    const reportForProject2 = createReport({
+      project_id: project2.id,
+      title: 'Report for Project 2',
+      type: 'detailed',
+      content: [],
+    });
+
+    const req = new Request('http://localhost/api/ai/generate-report-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: project1.id, reportId: reportForProject2.id }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
   it('returns 500 when AI provider throws an error', async () => {
     const mockGenerate = vi.fn().mockRejectedValue(new Error('Rate limit exceeded'));
     mockGetAIProvider.mockReturnValue({

--- a/src/app/api/ai/generate-report-summary/__tests__/route.test.ts
+++ b/src/app/api/ai/generate-report-summary/__tests__/route.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { createReport } from '@/lib/db/reports';
+
+// Mock the AI lib before importing the route
+vi.mock('@/lib/ai', () => ({
+  getAIProvider: vi.fn(),
+}));
+
+import { POST } from '../route';
+import { getAIProvider } from '@/lib/ai';
+
+const mockGetAIProvider = vi.mocked(getAIProvider);
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getDb().prepare('DELETE FROM reports').run();
+  getDb().prepare('DELETE FROM assessments').run();
+  getDb().prepare('DELETE FROM projects').run();
+});
+
+describe('POST /api/ai/generate-report-summary', () => {
+  it('returns 503 when AI is not configured', async () => {
+    mockGetAIProvider.mockReturnValue(null);
+
+    const req = new Request('http://localhost/api/ai/generate-report-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'p1', reportId: 'r1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toEqual({
+      success: false,
+      error: 'AI not configured',
+      code: 'AI_NOT_CONFIGURED',
+    });
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const req = new Request('http://localhost/api/ai/generate-report-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'p1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 when project does not exist', async () => {
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const req = new Request('http://localhost/api/ai/generate-report-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'nonexistent', reportId: 'r1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  it('generates summary and returns it', async () => {
+    const mockGenerate = vi.fn().mockResolvedValue('This is an AI-generated summary.');
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: mockGenerate,
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const project = createProject({ name: 'Test Project' });
+    const report = createReport({
+      project_id: project.id,
+      title: 'Test Report',
+      type: 'detailed',
+      content: [],
+    });
+
+    const req = new Request('http://localhost/api/ai/generate-report-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: project.id, reportId: report.id }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.summary).toBe('This is an AI-generated summary.');
+    expect(mockGenerate).toHaveBeenCalledWith(expect.any(String), 'Executive Summary');
+  });
+
+  it('returns 500 when AI provider throws an error', async () => {
+    const mockGenerate = vi.fn().mockRejectedValue(new Error('Rate limit exceeded'));
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: mockGenerate,
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const project = createProject({ name: 'Test Project 2' });
+    const report = createReport({
+      project_id: project.id,
+      title: 'Test Report 2',
+      type: 'detailed',
+      content: [],
+    });
+
+    const req = new Request('http://localhost/api/ai/generate-report-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: project.id, reportId: report.id }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('AI_ERROR');
+  });
+});

--- a/src/app/api/ai/generate-report-summary/route.ts
+++ b/src/app/api/ai/generate-report-summary/route.ts
@@ -55,6 +55,13 @@ export async function POST(request: Request) {
     );
   }
 
+  if (report.project_id !== projectId) {
+    return NextResponse.json(
+      { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+
   // Gather context: assessments and all issues for this project
   const assessments = getAssessments(projectId);
   const allIssues = assessments.flatMap((a) => getIssues(a.id));

--- a/src/app/api/ai/generate-report-summary/route.ts
+++ b/src/app/api/ai/generate-report-summary/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { getAIProvider } from '@/lib/ai';
+import { getProject } from '@/lib/db/projects';
+import { getAssessments } from '@/lib/db/assessments';
+import { getIssues } from '@/lib/db/issues';
+import { getReport } from '@/lib/db/reports';
+
+export async function POST(request: Request) {
+  const ai = getAIProvider();
+  if (!ai) {
+    return NextResponse.json(
+      { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const { projectId, reportId } = body as Record<string, unknown>;
+
+  if (typeof projectId !== 'string' || !projectId.trim()) {
+    return NextResponse.json(
+      { success: false, error: 'projectId is required', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+  if (typeof reportId !== 'string' || !reportId.trim()) {
+    return NextResponse.json(
+      { success: false, error: 'reportId is required', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const project = getProject(projectId);
+  if (!project) {
+    return NextResponse.json(
+      { success: false, error: 'Project not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+
+  const report = getReport(reportId);
+  if (!report) {
+    return NextResponse.json(
+      { success: false, error: 'Report not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+
+  // Gather context: assessments and all issues for this project
+  const assessments = getAssessments(projectId);
+  const allIssues = assessments.flatMap((a) => getIssues(a.id));
+
+  const context = [
+    `Project: ${project.name}`,
+    project.description ? `Description: ${project.description}` : '',
+    `Report: ${report.title} (${report.type})`,
+    `Total assessments: ${assessments.length}`,
+    `Total issues: ${allIssues.length}`,
+    allIssues.length > 0
+      ? `Issues:\n${allIssues
+          .map(
+            (i) =>
+              `- [${i.severity.toUpperCase()}] ${i.title}${i.wcag_codes.length ? ` (WCAG: ${i.wcag_codes.join(', ')})` : ''}`
+          )
+          .join('\n')}`
+      : 'No issues found.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  try {
+    const summary = await ai.generateReportSection(context, 'Executive Summary');
+    return NextResponse.json({
+      success: true,
+      data: { summary },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'AI request failed';
+    return NextResponse.json({ success: false, error: message, code: 'AI_ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/ai/generate-vpat-narrative/__tests__/route.test.ts
+++ b/src/app/api/ai/generate-vpat-narrative/__tests__/route.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+
+// Mock the AI lib before importing the route
+vi.mock('@/lib/ai', () => ({
+  getAIProvider: vi.fn(),
+}));
+
+import { POST } from '../route';
+import { getAIProvider } from '@/lib/ai';
+
+const mockGetAIProvider = vi.mocked(getAIProvider);
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getDb().prepare('DELETE FROM issues').run();
+  getDb().prepare('DELETE FROM assessments').run();
+  getDb().prepare('DELETE FROM projects').run();
+});
+
+describe('POST /api/ai/generate-vpat-narrative', () => {
+  it('returns 503 when AI is not configured', async () => {
+    mockGetAIProvider.mockReturnValue(null);
+
+    const req = new Request('http://localhost/api/ai/generate-vpat-narrative', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'p1', criterionCode: '1.1.1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toEqual({
+      success: false,
+      error: 'AI not configured',
+      code: 'AI_NOT_CONFIGURED',
+    });
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const req = new Request('http://localhost/api/ai/generate-vpat-narrative', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'p1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 404 when project does not exist', async () => {
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const req = new Request('http://localhost/api/ai/generate-vpat-narrative', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: 'nonexistent', criterionCode: '1.1.1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  it('generates narrative and returns it', async () => {
+    const mockRemarks = vi
+      .fn()
+      .mockResolvedValue('Supports criterion 1.1.1 with minor exceptions.');
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: mockRemarks,
+      testConnection: vi.fn(),
+    });
+
+    const project = createProject({ name: 'Test Project' });
+
+    const req = new Request('http://localhost/api/ai/generate-vpat-narrative', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: project.id, criterionCode: '1.1.1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.narrative).toBe('Supports criterion 1.1.1 with minor exceptions.');
+    expect(mockRemarks).toHaveBeenCalledWith(expect.any(String), '1.1.1');
+  });
+
+  it('returns 500 when AI provider throws an error', async () => {
+    const mockRemarks = vi.fn().mockRejectedValue(new Error('API error'));
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: mockRemarks,
+      testConnection: vi.fn(),
+    });
+
+    const project = createProject({ name: 'Test Project 2' });
+
+    const req = new Request('http://localhost/api/ai/generate-vpat-narrative', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: project.id, criterionCode: '1.1.1' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('AI_ERROR');
+  });
+});

--- a/src/app/api/ai/generate-vpat-narrative/route.ts
+++ b/src/app/api/ai/generate-vpat-narrative/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { getAIProvider } from '@/lib/ai';
+import { getProject } from '@/lib/db/projects';
+import { getAssessments } from '@/lib/db/assessments';
+import { getIssues } from '@/lib/db/issues';
+
+export async function POST(request: Request) {
+  const ai = getAIProvider();
+  if (!ai) {
+    return NextResponse.json(
+      { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const { projectId, criterionCode } = body as Record<string, unknown>;
+
+  if (typeof projectId !== 'string' || !projectId.trim()) {
+    return NextResponse.json(
+      { success: false, error: 'projectId is required', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+  if (typeof criterionCode !== 'string' || !criterionCode.trim()) {
+    return NextResponse.json(
+      { success: false, error: 'criterionCode is required', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const project = getProject(projectId);
+  if (!project) {
+    return NextResponse.json(
+      { success: false, error: 'Project not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+
+  // Gather issues for the project matching the criterion code
+  const assessments = getAssessments(projectId);
+  const matchingIssues = assessments.flatMap((a) => getIssues(a.id, { wcag_code: criterionCode }));
+
+  const issueSummary =
+    matchingIssues.length > 0
+      ? `Issues related to criterion ${criterionCode}:\n${matchingIssues
+          .map(
+            (i) =>
+              `- [${i.severity.toUpperCase()}] ${i.title}: ${i.description ?? 'No description'}`
+          )
+          .join('\n')}`
+      : `No specific issues found for criterion ${criterionCode} in project "${project.name}".`;
+
+  try {
+    const narrative = await ai.generateVpatRemarks(issueSummary, criterionCode);
+    return NextResponse.json({
+      success: true,
+      data: { narrative },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'AI request failed';
+    return NextResponse.json({ success: false, error: message, code: 'AI_ERROR' }, { status: 500 });
+  }
+}

--- a/src/app/api/ai/suggest-wcag/__tests__/route.test.ts
+++ b/src/app/api/ai/suggest-wcag/__tests__/route.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the AI lib before importing the route
+vi.mock('@/lib/ai', () => ({
+  getAIProvider: vi.fn(),
+}));
+
+import { POST } from '../route';
+import { getAIProvider } from '@/lib/ai';
+
+const mockGetAIProvider = vi.mocked(getAIProvider);
+
+describe('POST /api/ai/suggest-wcag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 503 when AI is not configured', async () => {
+    mockGetAIProvider.mockReturnValue(null);
+
+    const req = new Request('http://localhost/api/ai/suggest-wcag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Missing alt text',
+        description: 'Image has no alt attribute',
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body).toEqual({
+      success: false,
+      error: 'AI not configured',
+      code: 'AI_NOT_CONFIGURED',
+    });
+  });
+
+  it('returns 400 when title is missing', async () => {
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: vi.fn(),
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const req = new Request('http://localhost/api/ai/suggest-wcag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'no title provided' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('calls analyzeIssue and returns suggested WCAG codes with confidence', async () => {
+    const mockAnalyze = vi.fn().mockResolvedValue({
+      title: 'Missing alt text',
+      description: 'Image has no alt attribute',
+      severity: 'high',
+      wcag_codes: ['1.1.1', '4.1.2'],
+      confidence: 0.87,
+    });
+
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: mockAnalyze,
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const req = new Request('http://localhost/api/ai/suggest-wcag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Missing alt text',
+        description: 'Image has no alt attribute',
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.codes).toEqual(['1.1.1', '4.1.2']);
+    expect(body.data.confidence).toBe(0.87);
+  });
+
+  it('returns 500 when AI provider throws an error', async () => {
+    const mockAnalyze = vi.fn().mockRejectedValue(new Error('API quota exceeded'));
+    mockGetAIProvider.mockReturnValue({
+      analyzeIssue: mockAnalyze,
+      generateReportSection: vi.fn(),
+      generateVpatRemarks: vi.fn(),
+      testConnection: vi.fn(),
+    });
+
+    const req = new Request('http://localhost/api/ai/suggest-wcag', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Missing alt text',
+        description: 'Image has no alt attribute',
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.code).toBe('AI_ERROR');
+  });
+});

--- a/src/app/api/ai/suggest-wcag/route.ts
+++ b/src/app/api/ai/suggest-wcag/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { getAIProvider } from '@/lib/ai';
+
+export async function POST(request: Request) {
+  const ai = getAIProvider();
+  if (!ai) {
+    return NextResponse.json(
+      { success: false, error: 'AI not configured', code: 'AI_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid JSON', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const { title, description } = body as Record<string, unknown>;
+
+  if (typeof title !== 'string' || !title.trim()) {
+    return NextResponse.json(
+      { success: false, error: 'title is required', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const plainText = description
+    ? `Title: ${title}\nDescription: ${description}`
+    : `Title: ${title}`;
+
+  try {
+    const result = await ai.analyzeIssue(plainText);
+    return NextResponse.json({
+      success: true,
+      data: {
+        codes: result.wcag_codes,
+        confidence: result.confidence,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'AI request failed';
+    return NextResponse.json({ success: false, error: message, code: 'AI_ERROR' }, { status: 500 });
+  }
+}

--- a/src/components/__tests__/issues/issue-form-ai.test.tsx
+++ b/src/components/__tests__/issues/issue-form-ai.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { IssueForm } from '@/components/issues/issue-form';
+
+describe('IssueForm AI Suggest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the AI Suggest button', () => {
+    render(<IssueForm onSubmit={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /ai suggest/i })).toBeInTheDocument();
+  });
+
+  it('shows loading state while AI is fetching', async () => {
+    let resolvePromise: (value: unknown) => void;
+    const fetchPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    vi.spyOn(global, 'fetch').mockReturnValueOnce(fetchPromise as Promise<Response>);
+
+    render(<IssueForm onSubmit={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/title/i), {
+      target: { value: 'Image missing alt text' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /ai suggest/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /suggesting/i })).toBeDisabled();
+    });
+
+    resolvePromise!({
+      ok: true,
+      json: async () => ({ success: true, data: { codes: ['1.1.1'], confidence: 0.9 } }),
+    });
+  });
+
+  it('pre-populates WCAG codes from AI suggestion', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { codes: ['1.1.1', '1.4.3'], confidence: 0.87 },
+      }),
+    } as Response);
+
+    render(<IssueForm onSubmit={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/title/i), {
+      target: { value: 'Image missing alt text' },
+    });
+    fireEvent.change(screen.getByLabelText(/description/i), {
+      target: { value: 'No alt attribute on img element' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /ai suggest/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/87% confidence/i)).toBeInTheDocument();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/ai/suggest-wcag',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('Image missing alt text'),
+      })
+    );
+  });
+
+  it('shows error message when AI is not configured', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        success: false,
+        error: 'AI not configured',
+        code: 'AI_NOT_CONFIGURED',
+      }),
+    } as Response);
+
+    render(<IssueForm onSubmit={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/title/i), {
+      target: { value: 'Some issue' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /ai suggest/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ai not configured/i)).toBeInTheDocument();
+    });
+  });
+
+  it('does not call fetch when title is empty', () => {
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    render(<IssueForm onSubmit={vi.fn()} />);
+
+    // Title is empty — click AI Suggest
+    fireEvent.click(screen.getByRole('button', { name: /ai suggest/i }));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/reports/report-form-ai.test.tsx
+++ b/src/components/__tests__/reports/report-form-ai.test.tsx
@@ -28,6 +28,11 @@ describe('ReportForm AI Generate Summary', () => {
     vi.clearAllMocks();
   });
 
+  it('does not render Generate with AI button in create mode', () => {
+    render(<ReportForm projects={[{ id: 'p1', name: 'Test Project' }]} />);
+    expect(screen.queryByRole('button', { name: /generate with ai/i })).not.toBeInTheDocument();
+  });
+
   it('renders the Generate with AI button when editing a report', () => {
     render(<ReportForm report={mockReport} />);
     expect(screen.getByRole('button', { name: /generate with ai/i })).toBeInTheDocument();

--- a/src/components/__tests__/reports/report-form-ai.test.tsx
+++ b/src/components/__tests__/reports/report-form-ai.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { ReportForm } from '@/components/reports/report-form';
+
+describe('ReportForm AI Generate Summary', () => {
+  const mockReport = {
+    id: 'r1',
+    project_id: 'p1',
+    title: 'Test Report',
+    type: 'detailed' as const,
+    status: 'draft' as const,
+    content: '[]',
+    template_id: null,
+    ai_generated: 0,
+    created_by: null,
+    published_at: null,
+    created_at: '2026-01-01T00:00:00',
+    updated_at: '2026-01-01T00:00:00',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the Generate with AI button when editing a report', () => {
+    render(<ReportForm report={mockReport} />);
+    expect(screen.getByRole('button', { name: /generate with ai/i })).toBeInTheDocument();
+  });
+
+  it('shows loading state while generating summary', async () => {
+    let resolvePromise: (value: unknown) => void;
+    const fetchPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    vi.spyOn(global, 'fetch').mockReturnValueOnce(fetchPromise as Promise<Response>);
+
+    render(<ReportForm report={mockReport} />);
+    fireEvent.click(screen.getByRole('button', { name: /generate with ai/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generating/i })).toBeDisabled();
+    });
+
+    resolvePromise!({
+      ok: true,
+      json: async () => ({ success: true, data: { summary: 'AI generated summary.' } }),
+    });
+  });
+
+  it('populates sections from AI-generated summary', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { summary: 'This project has several critical accessibility issues.' },
+      }),
+    } as Response);
+
+    render(<ReportForm report={mockReport} />);
+    fireEvent.click(screen.getByRole('button', { name: /generate with ai/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/ai/generate-report-summary',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('r1'),
+        })
+      );
+    });
+  });
+
+  it('shows error when AI is not configured', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        success: false,
+        error: 'AI not configured',
+        code: 'AI_NOT_CONFIGURED',
+      }),
+    } as Response);
+
+    render(<ReportForm report={mockReport} />);
+    fireEvent.click(screen.getByRole('button', { name: /generate with ai/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ai not configured/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/vpats/vpat-criteria-table-ai.test.tsx
+++ b/src/components/__tests__/vpats/vpat-criteria-table-ai.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { VpatCriteriaTable } from '@/components/vpats/vpat-criteria-table';
+import type { CriterionRow } from '@/components/vpats/vpat-criteria-table';
+
+const mockCriteria: CriterionRow[] = [
+  {
+    criterion_code: '1.1.1',
+    conformance: 'supports',
+    remarks: null,
+    related_issue_ids: [],
+  },
+  {
+    criterion_code: '1.3.1',
+    conformance: 'does_not_support',
+    remarks: 'Heading structure is broken',
+    related_issue_ids: [],
+  },
+];
+
+describe('VpatCriteriaTable AI Generate Narrative', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders AI Generate buttons for each criterion when projectId is provided', () => {
+    render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} projectId="p1" />);
+    const aiButtons = screen.getAllByRole('button', { name: /ai generate/i });
+    expect(aiButtons.length).toBeGreaterThan(0);
+  });
+
+  it('does not render AI Generate buttons without projectId', () => {
+    render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} />);
+    expect(screen.queryAllByRole('button', { name: /ai generate/i })).toHaveLength(0);
+  });
+
+  it('shows loading state while generating narrative', async () => {
+    let resolvePromise: (value: unknown) => void;
+    const fetchPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    vi.spyOn(global, 'fetch').mockReturnValueOnce(fetchPromise as Promise<Response>);
+
+    render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} projectId="p1" />);
+
+    const aiButtons = screen.getAllByRole('button', { name: /ai generate/i });
+    fireEvent.click(aiButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generating narrative for/i })).toBeDisabled();
+    });
+
+    resolvePromise!({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { narrative: 'Fully supports non-text content alternatives.' },
+      }),
+    });
+  });
+
+  it('calls onChange with updated remarks after AI generates narrative', async () => {
+    const onChange = vi.fn();
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { narrative: 'Fully supports non-text content alternatives.' },
+      }),
+    } as Response);
+
+    render(<VpatCriteriaTable criteria={mockCriteria} onChange={onChange} projectId="p1" />);
+
+    const aiButtons = screen.getAllByRole('button', { name: /ai generate/i });
+    fireEvent.click(aiButtons[0]);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            criterion_code: '1.1.1',
+            remarks: 'Fully supports non-text content alternatives.',
+          }),
+        ])
+      );
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/ai/generate-vpat-narrative',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('1.1.1'),
+      })
+    );
+  });
+
+  it('shows error when AI narrative generation fails', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        success: false,
+        error: 'AI not configured',
+        code: 'AI_NOT_CONFIGURED',
+      }),
+    } as Response);
+
+    render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} projectId="p1" />);
+
+    const aiButtons = screen.getAllByRole('button', { name: /ai generate/i });
+    fireEvent.click(aiButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ai not configured/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/vpats/vpat-criteria-table-ai.test.tsx
+++ b/src/components/__tests__/vpats/vpat-criteria-table-ai.test.tsx
@@ -44,7 +44,7 @@ describe('VpatCriteriaTable AI Generate Narrative', () => {
     render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} projectId="p1" />);
 
     const aiButtons = screen.getAllByRole('button', { name: /ai generate/i });
-    fireEvent.click(aiButtons[0]);
+    fireEvent.click(aiButtons[0]!);
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /generating narrative for/i })).toBeDisabled();
@@ -72,7 +72,7 @@ describe('VpatCriteriaTable AI Generate Narrative', () => {
     render(<VpatCriteriaTable criteria={mockCriteria} onChange={onChange} projectId="p1" />);
 
     const aiButtons = screen.getAllByRole('button', { name: /ai generate/i });
-    fireEvent.click(aiButtons[0]);
+    fireEvent.click(aiButtons[0]!);
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(
@@ -108,7 +108,7 @@ describe('VpatCriteriaTable AI Generate Narrative', () => {
     render(<VpatCriteriaTable criteria={mockCriteria} onChange={vi.fn()} projectId="p1" />);
 
     const aiButtons = screen.getAllByRole('button', { name: /ai generate/i });
-    fireEvent.click(aiButtons[0]);
+    fireEvent.click(aiButtons[0]!);
 
     await waitFor(() => {
       expect(screen.getByText(/ai not configured/i)).toBeInTheDocument();

--- a/src/components/issues/issue-form.tsx
+++ b/src/components/issues/issue-form.tsx
@@ -35,6 +35,11 @@ export function IssueForm({ issue, onSubmit, loading }: IssueFormProps) {
   const [os, setOs] = useState(issue?.operating_system ?? '');
   const [assistiveTech, setAssistiveTech] = useState(issue?.assistive_technology ?? '');
 
+  // AI suggest state
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiConfidence, setAiConfidence] = useState<number | null>(null);
+  const [aiError, setAiError] = useState<string | null>(null);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const data: CreateIssueInput = {
@@ -51,6 +56,38 @@ export function IssueForm({ issue, onSubmit, loading }: IssueFormProps) {
       assistive_technology: assistiveTech || undefined,
     };
     onSubmit(data);
+  };
+
+  const handleAiSuggest = async () => {
+    if (!title.trim()) return;
+
+    setAiLoading(true);
+    setAiError(null);
+    setAiConfidence(null);
+
+    try {
+      const res = await fetch('/api/ai/suggest-wcag', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, description }),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok || !json.success) {
+        const errMsg = json.error ?? 'Failed to get AI suggestion';
+        setAiError(errMsg);
+        return;
+      }
+
+      const { codes, confidence } = json.data as { codes: string[]; confidence: number };
+      setWcagCodes(codes);
+      setAiConfidence(confidence);
+    } catch {
+      setAiError('Failed to connect to AI service');
+    } finally {
+      setAiLoading(false);
+    }
   };
 
   return (
@@ -123,7 +160,26 @@ export function IssueForm({ issue, onSubmit, loading }: IssueFormProps) {
           </div>
 
           <div className="space-y-1.5">
-            <Label>WCAG Criteria</Label>
+            <div className="flex items-center justify-between">
+              <Label>WCAG Criteria</Label>
+              <div className="flex items-center gap-2">
+                {aiConfidence !== null && (
+                  <span className="text-xs text-muted-foreground">
+                    {Math.round(aiConfidence * 100)}% confidence
+                  </span>
+                )}
+                {aiError && <span className="text-xs text-destructive">{aiError}</span>}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAiSuggest}
+                  disabled={aiLoading || !title.trim()}
+                >
+                  {aiLoading ? 'Suggesting…' : 'AI Suggest'}
+                </Button>
+              </div>
+            </div>
             <WcagSelector selected={wcagCodes} onChange={setWcagCodes} />
           </div>
 

--- a/src/components/reports/report-form.tsx
+++ b/src/components/reports/report-form.tsx
@@ -43,6 +43,10 @@ export function ReportForm({ report, projects = [] }: ReportFormProps) {
   const [sections, setSections] = useState<EditorSection[]>(initialSections);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // AI generate state
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!title.trim()) {
@@ -83,6 +87,46 @@ export function ReportForm({ report, projects = [] }: ReportFormProps) {
       toast.error('Failed to save report');
     } finally {
       setIsSubmitting(false);
+    }
+  }
+
+  async function handleGenerateWithAI() {
+    if (!report) return;
+
+    setAiLoading(true);
+    setAiError(null);
+
+    try {
+      const res = await fetch('/api/ai/generate-report-summary', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId: report.project_id, reportId: report.id }),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok || !json.success) {
+        const errMsg = json.error ?? 'Failed to generate summary';
+        setAiError(errMsg);
+        return;
+      }
+
+      const { summary } = json.data as { summary: string };
+
+      // Add the generated summary as a new section (or replace first section)
+      const summarySection: EditorSection = {
+        title: 'Executive Summary',
+        content: summary,
+      };
+
+      setSections((prev) => {
+        const existing = prev.filter((s) => s.title !== 'Executive Summary');
+        return [summarySection, ...existing];
+      });
+    } catch {
+      setAiError('Failed to connect to AI service');
+    } finally {
+      setAiLoading(false);
     }
   }
 
@@ -137,7 +181,23 @@ export function ReportForm({ report, projects = [] }: ReportFormProps) {
           </div>
 
           <div className="space-y-2">
-            <Label>Sections</Label>
+            <div className="flex items-center justify-between">
+              <Label>Sections</Label>
+              {isEdit && (
+                <div className="flex items-center gap-2">
+                  {aiError && <span className="text-xs text-destructive">{aiError}</span>}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleGenerateWithAI}
+                    disabled={aiLoading}
+                  >
+                    {aiLoading ? 'Generating…' : 'Generate with AI'}
+                  </Button>
+                </div>
+              )}
+            </div>
             <SectionEditor sections={sections} onChange={setSections} />
           </div>
         </div>
@@ -153,6 +213,9 @@ export function ReportForm({ report, projects = [] }: ReportFormProps) {
               <li>Each section has a title and body content.</li>
               <li>Markdown formatting is supported in section content.</li>
               <li>Published reports cannot be edited.</li>
+              {isEdit && (
+                <li>Use &ldquo;Generate with AI&rdquo; to auto-generate an executive summary.</li>
+              )}
             </ul>
           </div>
         </aside>

--- a/src/components/vpats/vpat-criteria-table.tsx
+++ b/src/components/vpats/vpat-criteria-table.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import {
   Table,
   TableBody,
@@ -16,6 +17,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
 import {
   WCAG_CRITERIA,
   CONFORMANCE_OPTIONS,
@@ -34,6 +36,8 @@ interface VpatCriteriaTableProps {
   criteria: CriterionRow[];
   onChange: (criteria: CriterionRow[]) => void;
   readOnly?: boolean;
+  /** When provided, shows AI Generate buttons per criterion */
+  projectId?: string;
 }
 
 const PRINCIPLES = ['Perceivable', 'Operable', 'Understandable', 'Robust'] as const;
@@ -42,15 +46,49 @@ export function VpatCriteriaTable({
   criteria,
   onChange,
   readOnly = false,
+  projectId,
 }: VpatCriteriaTableProps) {
+  const [aiLoadingCode, setAiLoadingCode] = useState<string | null>(null);
+  const [aiError, setAiError] = useState<string | null>(null);
+
   const updateRow = (criterion_code: string, field: keyof CriterionRow, value: string) => {
     onChange(
       criteria.map((r) => (r.criterion_code === criterion_code ? { ...r, [field]: value } : r))
     );
   };
 
+  const handleAiGenerate = async (criterionCode: string) => {
+    if (!projectId) return;
+
+    setAiLoadingCode(criterionCode);
+    setAiError(null);
+
+    try {
+      const res = await fetch('/api/ai/generate-vpat-narrative', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId, criterionCode }),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok || !json.success) {
+        setAiError(json.error ?? 'Failed to generate narrative');
+        return;
+      }
+
+      const { narrative } = json.data as { narrative: string };
+      updateRow(criterionCode, 'remarks', narrative);
+    } catch {
+      setAiError('Failed to connect to AI service');
+    } finally {
+      setAiLoadingCode(null);
+    }
+  };
+
   return (
     <div className="space-y-8">
+      {aiError && <p className="text-sm text-destructive">{aiError}</p>}
       {PRINCIPLES.map((principle) => {
         const rows = criteria.filter((r) => {
           const meta = WCAG_CRITERIA.find((c) => c.criterion === r.criterion_code);
@@ -69,6 +107,7 @@ export function VpatCriteriaTable({
                   <TableHead className="w-16">Level</TableHead>
                   <TableHead className="w-48">Conformance</TableHead>
                   <TableHead>Remarks</TableHead>
+                  {projectId && !readOnly && <TableHead className="w-32">AI</TableHead>}
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -78,6 +117,7 @@ export function VpatCriteriaTable({
                   const displayConformance =
                     CONFORMANCE_DISPLAY[row.conformance as keyof typeof CONFORMANCE_DISPLAY] ??
                     row.conformance;
+                  const isGenerating = aiLoadingCode === row.criterion_code;
 
                   return (
                     <TableRow key={row.criterion_code}>
@@ -134,6 +174,24 @@ export function VpatCriteriaTable({
                           />
                         )}
                       </TableCell>
+                      {projectId && !readOnly && (
+                        <TableCell>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleAiGenerate(row.criterion_code)}
+                            disabled={isGenerating}
+                            aria-label={
+                              isGenerating
+                                ? `Generating narrative for ${row.criterion_code}`
+                                : `AI Generate for ${row.criterion_code}`
+                            }
+                          >
+                            {isGenerating ? 'Generating…' : 'AI Generate'}
+                          </Button>
+                        </TableCell>
+                      )}
                     </TableRow>
                   );
                 })}

--- a/src/lib/db/reports.ts
+++ b/src/lib/db/reports.ts
@@ -22,6 +22,11 @@ export interface Report {
   updated_at: string;
 }
 
+export interface ReportSection {
+  title: string;
+  body: string;
+}
+
 export function getReport(id: string): Report | null {
   return (
     (getDb().prepare('SELECT * FROM reports WHERE id = ?').get(id) as Report | undefined) ?? null


### PR DESCRIPTION
## Summary
- "AI Suggest" button in `IssueForm` — calls `/api/ai/suggest-wcag`, pre-populates WCAG selector with confidence score
- "Generate with AI" button in report edit — calls `/api/ai/generate-report-summary`
- Per-criterion "AI Generate" buttons in VPAT criteria table — calls `/api/ai/generate-vpat-narrative`
- All buttons show loading state; graceful 503 when AI not configured

## Test Plan
- [ ] Unit tests: 56 files, 527 tests passing
- [ ] Lint, type-check, format all clean
- [ ] With AI configured: use AI Suggest on an issue → codes populated
- [ ] Without AI: buttons show appropriate error message