### PR TITLE
feat: issue status alignment — populate resolved_at/resolved_by on status transitions

### DIFF
--- a/src/app/api/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/__tests__/route.test.ts
+++ b/src/app/api/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/__tests__/route.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import { initDb, closeDb, getDb } from '@/lib/db/index';
 import { createProject } from '@/lib/db/projects';
 import { createAssessment } from '@/lib/db/assessments';
 import { createIssue } from '@/lib/db/issues';
 import { GET, PUT, DELETE } from '../route';
+
+vi.mock('@/lib/auth/session', () => ({ getSession: vi.fn() }));
+import { getSession } from '@/lib/auth/session';
 
 let projectId: string;
 let assessmentId: string;
@@ -19,6 +22,7 @@ afterAll(() => {
 });
 
 beforeEach(async () => {
+  vi.mocked(getSession).mockResolvedValue(null);
   getDb().prepare('DELETE FROM issues').run();
   getDb().prepare('DELETE FROM assessments').run();
   getDb().prepare('DELETE FROM projects').run();
@@ -192,6 +196,42 @@ describe('PUT /api/projects/[projectId]/assessments/[assessmentId]/issues/[issue
     });
     const response = await PUT(request, makeContext(projectId, otherAssessment.id, issueId));
     expect(response.status).toBe(404);
+  });
+
+  it('passes the session user id to updateIssue when authenticated', async () => {
+    vi.mocked(getSession).mockResolvedValue('user-abc');
+    const updateIssueSpy = vi.spyOn(await import('@/lib/db/issues'), 'updateIssue');
+
+    const req = new Request('http://localhost/api/test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'resolved' }),
+    });
+    const res = await PUT(req, makeContext(projectId, assessmentId, issueId));
+    const body = await res.json();
+
+    expect(updateIssueSpy).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: 'resolved' }),
+      'user-abc'
+    );
+    expect(body.data.resolved_by).toBe('user-abc');
+    updateIssueSpy.mockRestore();
+  });
+
+  it('passes null as resolvedBy when no session', async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const updateIssueSpy = vi.spyOn(await import('@/lib/db/issues'), 'updateIssue');
+
+    const req = new Request('http://localhost/api/test', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'resolved' }),
+    });
+    await PUT(req, makeContext(projectId, assessmentId, issueId));
+
+    expect(updateIssueSpy).toHaveBeenCalledWith(issueId, expect.anything(), null);
+    updateIssueSpy.mockRestore();
   });
 });
 

--- a/src/app/api/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/route.ts
+++ b/src/app/api/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/route.ts
@@ -3,6 +3,7 @@ import { getProject } from '@/lib/db/projects';
 import { getAssessment } from '@/lib/db/assessments';
 import { getIssue, updateIssue, deleteIssue } from '@/lib/db/issues';
 import { UpdateIssueSchema } from '@/lib/validators/issues';
+import { getSession } from '@/lib/auth/session';
 
 type RouteContext = {
   params: Promise<{ projectId: string; assessmentId: string; issueId: string }>;
@@ -59,6 +60,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
 
 export async function PUT(request: Request, { params }: RouteContext) {
   const { projectId, assessmentId, issueId } = await params;
+  const userId = await getSession();
 
   try {
     const resolved = await resolveIssueFromContext(projectId, assessmentId, issueId);
@@ -78,7 +80,7 @@ export async function PUT(request: Request, { params }: RouteContext) {
       );
     }
 
-    const updated = await updateIssue(issueId, result.data);
+    const updated = await updateIssue(issueId, result.data, userId);
     if (!updated) {
       return NextResponse.json(
         { success: false, error: 'Issue not found', code: 'NOT_FOUND' },

--- a/src/lib/db/__tests__/issues.test.ts
+++ b/src/lib/db/__tests__/issues.test.ts
@@ -279,6 +279,57 @@ describe('updateIssue', () => {
     const result = await updateIssue(created.id, {});
     expect(result!.title).toBe('No-op');
   });
+
+  it('sets resolved_at and resolved_by when status transitions to resolved', async () => {
+    const created = await createIssue(assessmentId, { title: 'Bug', status: 'open' });
+    const updated = await updateIssue(created.id, { status: 'resolved' }, 'user-123');
+    expect(updated!.status).toBe('resolved');
+    expect(updated!.resolved_at).not.toBeNull();
+    expect(updated!.resolved_by).toBe('user-123');
+  });
+
+  it('sets resolved_by to null when no user provided', async () => {
+    const created = await createIssue(assessmentId, { title: 'Bug' });
+    const updated = await updateIssue(created.id, { status: 'resolved' });
+    expect(updated!.resolved_at).not.toBeNull();
+    expect(updated!.resolved_by).toBeNull();
+  });
+
+  it('clears resolved_at and resolved_by when transitioning away from resolved', async () => {
+    const created = await createIssue(assessmentId, { title: 'Bug' });
+    await updateIssue(created.id, { status: 'resolved' }, 'user-123');
+    const reopened = await updateIssue(created.id, { status: 'open' });
+    expect(reopened!.status).toBe('open');
+    expect(reopened!.resolved_at).toBeNull();
+    expect(reopened!.resolved_by).toBeNull();
+  });
+
+  it('does not overwrite resolved_at when already resolved', async () => {
+    const created = await createIssue(assessmentId, { title: 'Bug' });
+    const first = await updateIssue(created.id, { status: 'resolved' }, 'user-123');
+    const firstResolvedAt = first!.resolved_at;
+    await new Promise((r) => setTimeout(r, 5));
+    const second = await updateIssue(created.id, { title: 'Updated title' });
+    expect(second!.resolved_at).toBe(firstResolvedAt);
+  });
+
+  it('does not touch resolved fields when status does not change', async () => {
+    const created = await createIssue(assessmentId, { title: 'Bug' });
+    await updateIssue(created.id, { status: 'resolved' }, 'user-123');
+    const resolved = await getIssue(created.id);
+    const updated = await updateIssue(created.id, { title: 'New title' });
+    expect(updated!.resolved_at).toBe(resolved!.resolved_at);
+    expect(updated!.resolved_by).toBe(resolved!.resolved_by);
+  });
+
+  it('clears resolved_at and resolved_by when transitioning from resolved to wont_fix', async () => {
+    const created = await createIssue(assessmentId, { title: 'Bug' });
+    await updateIssue(created.id, { status: 'resolved' }, 'user-123');
+    const wonFix = await updateIssue(created.id, { status: 'wont_fix' });
+    expect(wonFix!.status).toBe('wont_fix');
+    expect(wonFix!.resolved_at).toBeNull();
+    expect(wonFix!.resolved_by).toBeNull();
+  });
 });
 
 // ─── deleteIssue ─────────────────────────────────────────────────────────────

--- a/src/lib/db/issues.ts
+++ b/src/lib/db/issues.ts
@@ -193,7 +193,11 @@ export async function createIssue(assessmentId: string, input: CreateIssueInput)
   return (await getIssue(id))!;
 }
 
-export async function updateIssue(id: string, input: UpdateIssueInput): Promise<Issue | null> {
+export async function updateIssue(
+  id: string,
+  input: UpdateIssueInput,
+  resolvedBy?: string | null
+): Promise<Issue | null> {
   const existing = await getIssue(id);
   if (!existing) return null;
 
@@ -221,6 +225,20 @@ export async function updateIssue(id: string, input: UpdateIssueInput): Promise<
   if (input.evidence_media !== undefined)
     values.evidence_media = JSON.stringify(input.evidence_media);
   if (input.tags !== undefined) values.tags = JSON.stringify(input.tags);
+
+  // Status transition audit fields
+  if (input.status !== undefined) {
+    const toResolved = input.status === 'resolved' && existing.status !== 'resolved';
+    const fromResolved = input.status !== 'resolved' && existing.status === 'resolved';
+    if (toResolved) {
+      values.resolved_at = new Date().toISOString();
+      values.resolved_by = resolvedBy ?? null;
+    } else if (fromResolved) {
+      values.resolved_at = null;
+      values.resolved_by = null;
+    }
+    // staying resolved: leave existing resolved_at / resolved_by untouched
+  }
 
   if (Object.keys(values).length === 0) return existing;
 

--- a/src/lib/db/issues.ts
+++ b/src/lib/db/issues.ts
@@ -259,22 +259,7 @@ export async function deleteIssue(id: string): Promise<boolean> {
 }
 
 export async function resolveIssue(id: string, resolvedBy: string): Promise<Issue | null> {
-  const existing = await getIssue(id);
-  if (!existing) return null;
-
-  const now = new Date().toISOString();
-  db()
-    .update(issues)
-    .set({
-      status: 'resolved',
-      resolved_by: resolvedBy,
-      resolved_at: now,
-      updated_at: now,
-    })
-    .where(eq(issues.id, id))
-    .run();
-
-  return getIssue(id);
+  return updateIssue(id, { status: 'resolved' }, resolvedBy);
 }
 
 export async function getIssuesByProject(projectId: string): Promise<Issue[]> {


### PR DESCRIPTION
## Summary

- `updateIssue()` now populates `resolved_at` and `resolved_by` when status transitions to `resolved`, and clears them when transitioning away
- `resolveIssue()` refactored to a one-line delegate to `updateIssue()`, eliminating duplicate logic
- Issue PUT route reads the session user via `getSession()` and passes it as `resolvedBy`, so authenticated resolutions are attributed correctly (`null` when no auth)

## Test Plan
- [ ] Update an issue to `resolved` via the edit form — verify `resolved_at` is set
- [ ] Reopen a resolved issue — verify `resolved_at` and `resolved_by` are cleared
- [ ] Resolve an issue while authenticated — verify `resolved_by` contains the user ID
- [ ] Resolve an issue without auth — verify `resolved_by` is `null`
- [ ] All 1242 tests pass (`npm test`)