### PR TITLE
Add OpenACR YAML import functionality

### DIFF
--- a/__tests__/components/vpats/vpats-list-view.test.tsx
+++ b/__tests__/components/vpats/vpats-list-view.test.tsx
@@ -1,7 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
 import { VpatsListView } from '@/components/vpats/vpats-list-view';
 import type { VpatWithProgress } from '@/lib/db/vpats';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/components/vpats/import-openacr-modal', () => ({
+  ImportOpenAcrModal: () => <button>Import from OpenACR</button>,
+}));
 
 const mockVpats: VpatWithProgress[] = [
   {

--- a/e2e/openacr-import.spec.ts
+++ b/e2e/openacr-import.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const sampleYaml = `
+title: Sample VPAT
+catalog: 2.4-edition-wcag-2.1-en
+notes: Imported from test
+chapters:
+  success_criteria_level_a:
+    criteria:
+      - num: "1.1.1"
+        components:
+          - name: web
+            adherence:
+              level: supports
+              notes: All images have descriptive alt text
+      - num: "1.3.1"
+        components:
+          - name: web
+            adherence:
+              level: partially-supports
+              notes: Some landmark regions missing
+  success_criteria_level_aa:
+    criteria:
+      - num: "1.4.3"
+        components:
+          - name: web
+            adherence:
+              level: does-not-support
+              notes: Multiple contrast failures found
+`.trim();
+
+test.describe('OpenACR YAML Import', () => {
+  let projectId: string;
+
+  test.beforeEach(async ({ request }) => {
+    const res = await request.post('/api/projects', {
+      data: { name: 'E2E OpenACR Import Project' },
+    });
+    expect(res.ok()).toBeTruthy();
+    projectId = (await res.json()).data.id;
+  });
+
+  test.afterEach(async ({ request }) => {
+    if (projectId) await request.delete(`/api/projects/${projectId}`);
+  });
+
+  test('creates a VPAT from an OpenACR YAML file', async ({ page }) => {
+    const yamlPath = path.join(os.tmpdir(), 'test-openacr.yaml');
+    fs.writeFileSync(yamlPath, sampleYaml);
+
+    try {
+      await page.goto('/vpats');
+
+      // Open modal
+      await page.getByRole('button', { name: /import from openacr/i }).click();
+
+      const dialog = page.getByRole('dialog');
+
+      // Step 1: select project
+      await expect(dialog.getByRole('heading', { name: /select project/i })).toBeVisible();
+      await dialog.locator('select').selectOption({ label: 'E2E OpenACR Import Project' });
+      await dialog.getByRole('button', { name: /^next$/i }).click();
+
+      // Step 2: upload file
+      await expect(dialog.getByRole('heading', { name: /upload openacr yaml/i })).toBeVisible();
+      await page.getByLabel(/yaml file/i).setInputFiles(yamlPath);
+      await expect(dialog.getByText('Sample VPAT')).toBeVisible();
+      await expect(dialog.getByText(/3 criteria/i)).toBeVisible();
+      await dialog.getByRole('button', { name: /^next$/i }).click();
+
+      // Step 3: confirm
+      await expect(dialog.getByRole('heading', { name: /confirm import/i })).toBeVisible();
+      await dialog.getByRole('button', { name: /^import$/i }).click();
+
+      // Redirected to VPAT detail page
+      await expect(page).toHaveURL(/\/vpats\//);
+      await expect(page.getByRole('heading', { name: 'Sample VPAT' })).toBeVisible({
+        timeout: 10000,
+      });
+    } finally {
+      fs.unlinkSync(yamlPath);
+    }
+  });
+
+  test('shows parse error for invalid YAML file', async ({ page }) => {
+    const badPath = path.join(os.tmpdir(), 'bad.yaml');
+    fs.writeFileSync(badPath, 'not: valid: {{{');
+
+    try {
+      await page.goto('/vpats');
+      await page.getByRole('button', { name: /import from openacr/i }).click();
+
+      const dialog = page.getByRole('dialog');
+      await expect(dialog.getByRole('heading', { name: /select project/i })).toBeVisible();
+      await dialog.locator('select').selectOption({ label: 'E2E OpenACR Import Project' });
+      await dialog.getByRole('button', { name: /^next$/i }).click();
+
+      await page.getByLabel(/yaml file/i).setInputFiles(badPath);
+
+      await expect(dialog.getByText(/could not parse yaml/i)).toBeVisible();
+    } finally {
+      fs.unlinkSync(badPath);
+    }
+  });
+});

--- a/src/app/(app)/vpats/[id]/page.tsx
+++ b/src/app/(app)/vpats/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Breadcrumbs } from '@/components/ui/breadcrumbs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -56,6 +57,9 @@ export default function VpatDetailPage() {
   const [panelIssues, setPanelIssues] = useState<PanelIssue[]>([]);
   // Incremented after generate-all so VpatCriteriaTable remounts with fresh RHF defaults.
   const [tableKey, setTableKey] = useState(0);
+  const [generateProgress, setGenerateProgress] = useState(0);
+  const [generateTotal, setGenerateTotal] = useState(0);
+  const [isGeneratingAll, setIsGeneratingAll] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -141,25 +145,35 @@ export default function VpatDetailPage() {
   );
 
   const handleGenerateAll = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/vpats/${vpatId}/rows/generate-all`, { method: 'POST' });
-      const json = await res.json();
-      if (!json.success) {
-        toast.error('AI generation failed');
-        return;
-      }
-      // Reload rows and remount table so RHF picks up new AI-generated remarks.
-      const reloadRes = await fetch(`/api/vpats/${vpatId}`);
-      const reloadJson = await reloadRes.json();
-      if (reloadJson.success) {
-        setRows(reloadJson.data.criterion_rows);
-        setTableKey((k) => k + 1);
-      }
-      toast.success(`Generated ${json.data.generated} criteria`);
-    } catch {
-      toast.error('AI generation failed');
+    const pending = rows.filter((r) => !r.remarks);
+    if (pending.length === 0) {
+      toast('All criteria already have remarks');
+      return;
     }
-  }, [vpatId]);
+
+    setGenerateTotal(pending.length);
+    setGenerateProgress(0);
+    setIsGeneratingAll(true);
+
+    let generated = 0;
+    for (const row of pending) {
+      try {
+        const res = await fetch(`/api/vpats/${vpatId}/rows/${row.id}/generate`, { method: 'POST' });
+        const json = await res.json();
+        if (json.success) {
+          setRows((prev) => prev.map((r) => (r.id === row.id ? json.data : r)));
+          generated++;
+        }
+      } catch {
+        // continue on error — best effort
+      }
+      setGenerateProgress((p) => p + 1);
+    }
+
+    setIsGeneratingAll(false);
+    setTableKey((k) => k + 1);
+    toast.success(`Generated ${generated} of ${pending.length} criteria`);
+  }, [vpatId, rows]);
 
   const handleCriterionClick = useCallback(
     async (criterionCode: string) => {
@@ -314,6 +328,28 @@ export default function VpatDetailPage() {
         aiEnabled={true}
         onCriterionClick={handleCriterionClick}
       />
+
+      {/* Generate All progress modal */}
+      <Dialog open={isGeneratingAll}>
+        <DialogContent className="max-w-sm" onInteractOutside={(e) => e.preventDefault()}>
+          <DialogHeader>
+            <DialogTitle>Generating Criteria</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <p className="text-sm text-muted-foreground">
+              {generateProgress} of {generateTotal} criteria generated
+            </p>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div
+                className="h-full bg-primary transition-all duration-300"
+                style={{
+                  width: generateTotal > 0 ? `${(generateProgress / generateTotal) * 100}%` : '0%',
+                }}
+              />
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {/* Issues panel */}
       {panelRowCode && (

--- a/src/app/api/vpats/import/__tests__/route.test.ts
+++ b/src/app/api/vpats/import/__tests__/route.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { getCriterionRows } from '@/lib/db/vpat-criterion-rows';
+import { POST } from '../route';
+
+let projectId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(async () => {
+  getDb().prepare('DELETE FROM vpat_criterion_rows').run();
+  getDb().prepare('DELETE FROM vpats').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = await createProject({ name: 'Import Test Project' });
+  projectId = project.id;
+});
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/vpats/import', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validYaml = `
+title: Test VPAT
+catalog: 2.4-edition-wcag-2.1-en
+notes: Test notes
+chapters:
+  success_criteria_level_a:
+    criteria:
+      - num: "1.1.1"
+        components:
+          - name: web
+            adherence:
+              level: supports
+              notes: All images have alt text
+  success_criteria_level_aa:
+    criteria:
+      - num: "1.4.3"
+        components:
+          - name: web
+            adherence:
+              level: partially-supports
+              notes: Some contrast issues
+`;
+
+describe('POST /api/vpats/import', () => {
+  it('creates a VPAT from valid OpenACR YAML', async () => {
+    const res = await POST(makeRequest({ projectId, yaml: validYaml }));
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBeDefined();
+    expect(body.data.skipped).toEqual([]);
+  });
+
+  it('creates criterion rows for criteria present in the YAML', async () => {
+    const res = await POST(makeRequest({ projectId, yaml: validYaml }));
+    const body = await res.json();
+    const rows = await getCriterionRows(body.data.id);
+    expect(rows).toHaveLength(2);
+    expect(rows.some((r) => r.conformance === 'supports')).toBe(true);
+    expect(rows.some((r) => r.conformance === 'partially_supports')).toBe(true);
+  });
+
+  it('skips criterion codes not found in the criteria table', async () => {
+    const yamlWithUnknown =
+      validYaml +
+      `
+      - num: "9.9.9"
+        components:
+          - name: web
+            adherence:
+              level: supports
+              notes: ""
+`;
+    const res = await POST(makeRequest({ projectId, yaml: yamlWithUnknown }));
+    const body = await res.json();
+    expect(body.data.skipped).toContain('9.9.9');
+  });
+
+  it('returns 400 for invalid YAML', async () => {
+    const res = await POST(makeRequest({ projectId, yaml: 'not: valid: yaml: {{{' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when catalog is missing', async () => {
+    const res = await POST(
+      makeRequest({
+        projectId,
+        yaml: 'title: X\nchapters: {}',
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing request fields', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown project', async () => {
+    const res = await POST(makeRequest({ projectId: 'nonexistent', yaml: validYaml }));
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/vpats/import/route.ts
+++ b/src/app/api/vpats/import/route.ts
@@ -12,89 +12,91 @@ const ImportRequestSchema = z.object({
 });
 
 export async function POST(request: Request) {
-  const body = await request.json().catch(() => null);
-  const result = ImportRequestSchema.safeParse(body);
-  if (!result.success) {
-    return NextResponse.json(
-      { success: false, error: 'Invalid request body', code: 'VALIDATION_ERROR' },
-      { status: 400 }
-    );
-  }
-
-  const { projectId, yaml } = result.data;
-
-  const project = await getProject(projectId);
-  if (!project) {
-    return NextResponse.json(
-      { success: false, error: 'Project not found', code: 'NOT_FOUND' },
-      { status: 404 }
-    );
-  }
-
-  let parsed: unknown;
   try {
-    parsed = jsYaml.load(yaml);
-  } catch {
-    return NextResponse.json(
-      { success: false, error: 'Invalid YAML', code: 'PARSE_ERROR' },
-      { status: 400 }
-    );
-  }
-
-  const openacr = parseOpenAcr(parsed);
-  if (!openacr) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'File does not appear to be a valid OpenACR YAML',
-        code: 'INVALID_FORMAT',
-      },
-      { status: 400 }
-    );
-  }
-
-  const codes = openacr.criteria.map((c) => c.code);
-  const codeMap = await getCriteriaByCode(codes);
-
-  const skipped: string[] = [];
-  const rows: Array<{
-    criterion_id: string;
-    conformance:
-      | 'supports'
-      | 'partially_supports'
-      | 'does_not_support'
-      | 'not_applicable'
-      | 'not_evaluated';
-    remarks: string | null;
-  }> = [];
-
-  for (const criterion of openacr.criteria) {
-    const criterionId = codeMap.get(criterion.code);
-    if (!criterionId) {
-      skipped.push(criterion.code);
-      continue;
+    const body = await request.json().catch(() => null);
+    const result = ImportRequestSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid request body', code: 'VALIDATION_ERROR' },
+        { status: 400 }
+      );
     }
-    rows.push({
-      criterion_id: criterionId,
-      conformance: criterion.conformance as
+
+    const { projectId, yaml } = result.data;
+
+    const project = await getProject(projectId);
+    if (!project) {
+      return NextResponse.json(
+        { success: false, error: 'Project not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = jsYaml.load(yaml);
+    } catch {
+      return NextResponse.json(
+        { success: false, error: 'Invalid YAML', code: 'PARSE_ERROR' },
+        { status: 400 }
+      );
+    }
+
+    const openacr = parseOpenAcr(parsed);
+    if (!openacr) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'File does not appear to be a valid OpenACR YAML',
+          code: 'INVALID_FORMAT',
+        },
+        { status: 400 }
+      );
+    }
+
+    const codes = openacr.criteria.map((c) => c.code);
+    const codeMap = await getCriteriaByCode(codes);
+
+    const skipped: string[] = [];
+    const rows: Array<{
+      criterion_id: string;
+      conformance:
         | 'supports'
         | 'partially_supports'
         | 'does_not_support'
         | 'not_applicable'
-        | 'not_evaluated',
-      remarks: criterion.remarks,
+        | 'not_evaluated';
+      remarks: string | null;
+    }> = [];
+
+    for (const criterion of openacr.criteria) {
+      const criterionId = codeMap.get(criterion.code);
+      if (!criterionId) {
+        skipped.push(criterion.code);
+        continue;
+      }
+      rows.push({
+        criterion_id: criterionId,
+        conformance: criterion.conformance,
+        remarks: criterion.remarks,
+      });
+    }
+
+    const vpat = await importVpatFromOpenAcr({
+      project_id: projectId,
+      title: openacr.title,
+      description: openacr.description,
+      standard_edition: openacr.standard_edition,
+      wcag_version: openacr.wcag_version,
+      wcag_level: openacr.wcag_level,
+      rows,
     });
+
+    return NextResponse.json({ success: true, data: { id: vpat.id, skipped } }, { status: 201 });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Internal server error', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
   }
-
-  const vpat = await importVpatFromOpenAcr({
-    project_id: projectId,
-    title: openacr.title,
-    description: openacr.description,
-    standard_edition: openacr.standard_edition,
-    wcag_version: openacr.wcag_version,
-    wcag_level: openacr.wcag_level,
-    rows,
-  });
-
-  return NextResponse.json({ success: true, data: { id: vpat.id, skipped } }, { status: 201 });
 }

--- a/src/app/api/vpats/import/route.ts
+++ b/src/app/api/vpats/import/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import jsYaml from 'js-yaml';
+import { getProject } from '@/lib/db/projects';
+import { importVpatFromOpenAcr } from '@/lib/db/vpats';
+import { getCriteriaByCode } from '@/lib/db/criteria';
+import { parseOpenAcr } from '@/lib/import/parse-openacr';
+
+const ImportRequestSchema = z.object({
+  projectId: z.string().min(1),
+  yaml: z.string().min(1),
+});
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const result = ImportRequestSchema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid request body', code: 'VALIDATION_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const { projectId, yaml } = result.data;
+
+  const project = await getProject(projectId);
+  if (!project) {
+    return NextResponse.json(
+      { success: false, error: 'Project not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = jsYaml.load(yaml);
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Invalid YAML', code: 'PARSE_ERROR' },
+      { status: 400 }
+    );
+  }
+
+  const openacr = parseOpenAcr(parsed);
+  if (!openacr) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'File does not appear to be a valid OpenACR YAML',
+        code: 'INVALID_FORMAT',
+      },
+      { status: 400 }
+    );
+  }
+
+  const codes = openacr.criteria.map((c) => c.code);
+  const codeMap = await getCriteriaByCode(codes);
+
+  const skipped: string[] = [];
+  const rows: Array<{
+    criterion_id: string;
+    conformance:
+      | 'supports'
+      | 'partially_supports'
+      | 'does_not_support'
+      | 'not_applicable'
+      | 'not_evaluated';
+    remarks: string | null;
+  }> = [];
+
+  for (const criterion of openacr.criteria) {
+    const criterionId = codeMap.get(criterion.code);
+    if (!criterionId) {
+      skipped.push(criterion.code);
+      continue;
+    }
+    rows.push({
+      criterion_id: criterionId,
+      conformance: criterion.conformance as
+        | 'supports'
+        | 'partially_supports'
+        | 'does_not_support'
+        | 'not_applicable'
+        | 'not_evaluated',
+      remarks: criterion.remarks,
+    });
+  }
+
+  const vpat = await importVpatFromOpenAcr({
+    project_id: projectId,
+    title: openacr.title,
+    description: openacr.description,
+    standard_edition: openacr.standard_edition,
+    wcag_version: openacr.wcag_version,
+    wcag_level: openacr.wcag_level,
+    rows,
+  });
+
+  return NextResponse.json({ success: true, data: { id: vpat.id, skipped } }, { status: 201 });
+}

--- a/src/components/vpats/__tests__/import-openacr-modal.test.tsx
+++ b/src/components/vpats/__tests__/import-openacr-modal.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ImportOpenAcrModal } from '../import-openacr-modal';
+
+vi.mock('js-yaml', () => ({
+  default: {
+    load: vi.fn(() => ({
+      title: 'Parsed VPAT',
+      catalog: '2.4-edition-wcag-2.1-en',
+      notes: '',
+      chapters: {
+        success_criteria_level_a: {
+          criteria: [
+            { num: '1.1.1', components: [{ adherence: { level: 'supports', notes: '' } }] },
+            { num: '1.3.1', components: [{ adherence: { level: 'supports', notes: '' } }] },
+          ],
+        },
+      },
+    })),
+  },
+}));
+
+const defaultProps = { onImportComplete: vi.fn() };
+
+describe('ImportOpenAcrModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: [{ id: 'p1', name: 'My Project' }] }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, data: { id: 'vpat-123', skipped: [] } }),
+      });
+  });
+
+  it('renders a trigger button', () => {
+    render(<ImportOpenAcrModal {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /import from openacr/i })).toBeInTheDocument();
+  });
+
+  it('opens the modal and shows step 1 (select project)', async () => {
+    render(<ImportOpenAcrModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /import from openacr/i }));
+    expect(screen.getByText(/select project/i)).toBeInTheDocument();
+  });
+
+  it('advances to step 2 after selecting a project', async () => {
+    render(<ImportOpenAcrModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /import from openacr/i }));
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'p1');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByText(/upload openacr yaml/i)).toBeInTheDocument();
+  });
+
+  it('shows a preview after uploading a valid YAML file', async () => {
+    render(<ImportOpenAcrModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /import from openacr/i }));
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'p1');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    const file = new File(['catalog: 2.4-edition-wcag-2.1-en\nchapters: {}'], 'vpat.yaml', {
+      type: 'application/yaml',
+    });
+    await userEvent.upload(screen.getByLabelText(/yaml file/i), file);
+
+    await waitFor(() => expect(screen.getByText('Parsed VPAT')).toBeInTheDocument());
+    expect(screen.getByText(/2 criteria/i)).toBeInTheDocument();
+  });
+
+  it('calls onImportComplete after successful import', async () => {
+    render(<ImportOpenAcrModal {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: /import from openacr/i }));
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'p1');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    const file = new File(['catalog: x\nchapters: {}'], 'vpat.yaml', { type: 'application/yaml' });
+    await userEvent.upload(screen.getByLabelText(/yaml file/i), file);
+    await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled());
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^import$/i }));
+
+    await waitFor(() => expect(defaultProps.onImportComplete).toHaveBeenCalledWith('vpat-123'));
+  });
+});

--- a/src/components/vpats/__tests__/vpats-list-view.test.tsx
+++ b/src/components/vpats/__tests__/vpats-list-view.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import { vi, describe, it, expect } from 'vitest';
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
 vi.mock('@/components/vpats/vpat-card', () => ({
   VpatCard: () => <div data-testid="vpat-card" />,
+}));
+
+vi.mock('@/components/vpats/import-openacr-modal', () => ({
+  ImportOpenAcrModal: () => <button>Import from OpenACR</button>,
 }));
 
 import { VpatsListView } from '../vpats-list-view';

--- a/src/components/vpats/import-openacr-modal.tsx
+++ b/src/components/vpats/import-openacr-modal.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import jsYaml from 'js-yaml';
+import { FileUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { parseOpenAcr, type OpenAcrParseResult } from '@/lib/import/parse-openacr';
+
+interface Project {
+  id: string;
+  name: string;
+}
+
+interface ImportOpenAcrModalProps {
+  onImportComplete: (vpatId: string) => void;
+}
+
+type Step = 'project' | 'upload' | 'confirm';
+
+export function ImportOpenAcrModal({ onImportComplete }: ImportOpenAcrModalProps) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<Step>('project');
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectId, setProjectId] = useState('');
+  const [parsed, setParsed] = useState<OpenAcrParseResult | null>(null);
+  const [yamlString, setYamlString] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      fetch('/api/projects')
+        .then((r) => r.json())
+        .then((body) => {
+          if (body.success) setProjects(body.data);
+        })
+        .catch(() => {});
+    }
+  }, [open]);
+
+  function reset() {
+    setStep('project');
+    setProjectId('');
+    setParsed(null);
+    setYamlString('');
+    setParseError(null);
+    setError(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }
+
+  function handleClose() {
+    setOpen(false);
+    reset();
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setParseError(null);
+    setParsed(null);
+
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result as string;
+      try {
+        const doc = jsYaml.load(text);
+        const result = parseOpenAcr(doc);
+        if (!result) {
+          setParseError(
+            'File does not appear to be a valid OpenACR YAML (missing catalog or chapters).'
+          );
+          return;
+        }
+        setYamlString(text);
+        setParsed(result);
+      } catch {
+        setParseError('Could not parse YAML. Please check the file format.');
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  async function handleImport() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/vpats/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ projectId, yaml: yamlString }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        handleClose();
+        onImportComplete(data.data.id);
+      } else {
+        setError(data.error ?? 'Import failed. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const selectedProject = projects.find((p) => p.id === projectId);
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        <FileUp className="mr-2 h-4 w-4" />
+        Import from OpenACR
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(v) => {
+          if (!v) handleClose();
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {step === 'project' && 'Select Project'}
+              {step === 'upload' && 'Upload OpenACR YAML'}
+              {step === 'confirm' && 'Confirm Import'}
+            </DialogTitle>
+          </DialogHeader>
+
+          {step === 'project' && (
+            <div className="space-y-2">
+              <label htmlFor="import-project-select" className="block text-sm font-medium">
+                Project
+              </label>
+              <select
+                id="import-project-select"
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+                className="block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              >
+                <option value="">— Select a project —</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {step === 'upload' && (
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="yaml-file-input" className="block text-sm font-medium mb-1">
+                  YAML File
+                </label>
+                <input
+                  id="yaml-file-input"
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".yaml,.yml"
+                  onChange={handleFileChange}
+                  className="block w-full text-sm"
+                />
+              </div>
+              {parseError && <p className="text-sm text-destructive">{parseError}</p>}
+              {parsed && (
+                <div className="rounded border p-3 text-sm space-y-1">
+                  <p className="font-medium">{parsed.title}</p>
+                  <p className="text-muted-foreground">
+                    {parsed.standard_edition} · WCAG {parsed.wcag_version} · Level{' '}
+                    {parsed.wcag_level}
+                  </p>
+                  <p className="text-muted-foreground">{parsed.criteria.length} criteria</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {step === 'confirm' && parsed && selectedProject && (
+            <div className="text-sm space-y-2">
+              <p>
+                Create VPAT for <strong>{selectedProject.name}</strong> from{' '}
+                <strong>{parsed.title}</strong>
+              </p>
+              <p className="text-muted-foreground">
+                {parsed.standard_edition} · WCAG {parsed.wcag_version} · Level {parsed.wcag_level} ·{' '}
+                {parsed.criteria.length} criteria
+              </p>
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <DialogFooter>
+            <Button variant="ghost" onClick={handleClose}>
+              Cancel
+            </Button>
+            {step === 'project' && (
+              <Button onClick={() => setStep('upload')} disabled={!projectId}>
+                Next
+              </Button>
+            )}
+            {step === 'upload' && (
+              <Button onClick={() => setStep('confirm')} disabled={!parsed}>
+                Next
+              </Button>
+            )}
+            {step === 'confirm' && (
+              <Button onClick={handleImport} disabled={loading}>
+                {loading ? 'Importing…' : 'Import'}
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/vpats/vpats-list-view.tsx
+++ b/src/components/vpats/vpats-list-view.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { ImportOpenAcrModal } from '@/components/vpats/import-openacr-modal';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ViewToggle } from '@/components/ui/view-toggle';
@@ -29,14 +31,18 @@ interface VpatsListViewProps {
 
 export function VpatsListView({ vpats }: VpatsListViewProps) {
   const [view, setView] = useState<'grid' | 'table'>('table');
+  const router = useRouter();
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">VPATs</h1>
-        <Button asChild>
-          <Link href="/vpats/new">New VPAT</Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          <ImportOpenAcrModal onImportComplete={(id) => router.push(`/vpats/${id}`)} />
+          <Button asChild>
+            <Link href="/vpats/new">New VPAT</Link>
+          </Button>
+        </div>
       </div>
       <div className="flex justify-end">
         <ViewToggle view={view} onViewChange={setView} />

--- a/src/lib/db/__tests__/criteria-by-code.test.ts
+++ b/src/lib/db/__tests__/criteria-by-code.test.ts
@@ -3,8 +3,12 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { initDb, closeDb } from '@/lib/db/index';
 import { getCriteriaByCode } from '@/lib/db/criteria';
 
-beforeAll(() => { initDb(':memory:'); });
-afterAll(() => { closeDb(); });
+beforeAll(() => {
+  initDb(':memory:');
+});
+afterAll(() => {
+  closeDb();
+});
 
 describe('getCriteriaByCode', () => {
   it('returns a map of code to id for known WCAG codes', async () => {

--- a/src/lib/db/__tests__/criteria-by-code.test.ts
+++ b/src/lib/db/__tests__/criteria-by-code.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { initDb, closeDb } from '@/lib/db/index';
+import { getCriteriaByCode } from '@/lib/db/criteria';
+
+beforeAll(() => { initDb(':memory:'); });
+afterAll(() => { closeDb(); });
+
+describe('getCriteriaByCode', () => {
+  it('returns a map of code to id for known WCAG codes', async () => {
+    const map = await getCriteriaByCode(['1.1.1', '1.3.1']);
+    expect(map.get('1.1.1')).toBeDefined();
+    expect(typeof map.get('1.1.1')).toBe('string');
+    expect(map.get('1.3.1')).toBeDefined();
+  });
+
+  it('returns empty map for empty input', async () => {
+    const map = await getCriteriaByCode([]);
+    expect(map.size).toBe(0);
+  });
+
+  it('omits codes that do not exist in the criteria table', async () => {
+    const map = await getCriteriaByCode(['9.9.9', '0.0.0']);
+    expect(map.size).toBe(0);
+  });
+
+  it('returns partial results when some codes exist and some do not', async () => {
+    const map = await getCriteriaByCode(['1.1.1', '9.9.9']);
+    expect(map.has('1.1.1')).toBe(true);
+    expect(map.has('9.9.9')).toBe(false);
+  });
+});

--- a/src/lib/db/__tests__/vpats.test.ts
+++ b/src/lib/db/__tests__/vpats.test.ts
@@ -15,8 +15,10 @@ import {
   publishVpat,
   getVpatsWithProject,
   getVpatsWithProgress,
+  importVpatFromOpenAcr,
 } from '../vpats';
 import { getCriterionRows } from '../vpat-criterion-rows';
+import { getCriteriaByCode } from '../criteria';
 
 function dbc() {
   return getDbClient() as BetterSQLite3Database<typeof sqliteSchema>;
@@ -339,5 +341,64 @@ describe('getVpatsWithProgress', () => {
     });
     const results = await getVpatsWithProgress();
     expect(results[0]!.resolved).toBe(0);
+  });
+});
+
+describe('importVpatFromOpenAcr', () => {
+  it('creates a VPAT with the given metadata', async () => {
+    const project = await createProject({ name: 'Import Test' });
+    const vpat = await importVpatFromOpenAcr({
+      project_id: project.id,
+      title: 'Imported VPAT',
+      description: 'From OpenACR',
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      rows: [],
+    });
+    expect(vpat.title).toBe('Imported VPAT');
+    expect(vpat.description).toBe('From OpenACR');
+    expect(vpat.standard_edition).toBe('WCAG');
+    expect(vpat.wcag_version).toBe('2.1');
+    expect(vpat.wcag_level).toBe('AA');
+    expect(vpat.status).toBe('draft');
+  });
+
+  it('creates only the criterion rows passed in (no auto-population)', async () => {
+    const project = await createProject({ name: 'Import Test 2' });
+    const codeMap = await getCriteriaByCode(['1.1.1', '1.4.3']);
+    const criterionId = codeMap.get('1.1.1')!;
+
+    const vpat = await importVpatFromOpenAcr({
+      project_id: project.id,
+      title: 'Sparse VPAT',
+      description: null,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      rows: [
+        { criterion_id: criterionId, conformance: 'supports', remarks: 'All images have alt text' },
+      ],
+    });
+
+    const rows = await getCriterionRows(vpat.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.conformance).toBe('supports');
+    expect(rows[0]!.remarks).toBe('All images have alt text');
+  });
+
+  it('creates a VPAT with zero rows when rows array is empty', async () => {
+    const project = await createProject({ name: 'Import Test 3' });
+    const vpat = await importVpatFromOpenAcr({
+      project_id: project.id,
+      title: 'Empty VPAT',
+      description: null,
+      standard_edition: '508',
+      wcag_version: '2.1',
+      wcag_level: 'A',
+      rows: [],
+    });
+    const rows = await getCriterionRows(vpat.id);
+    expect(rows).toHaveLength(0);
   });
 });

--- a/src/lib/db/__tests__/vpats.test.ts
+++ b/src/lib/db/__tests__/vpats.test.ts
@@ -346,9 +346,8 @@ describe('getVpatsWithProgress', () => {
 
 describe('importVpatFromOpenAcr', () => {
   it('creates a VPAT with the given metadata', async () => {
-    const project = await createProject({ name: 'Import Test' });
     const vpat = await importVpatFromOpenAcr({
-      project_id: project.id,
+      project_id: projectId,
       title: 'Imported VPAT',
       description: 'From OpenACR',
       standard_edition: 'WCAG',
@@ -365,12 +364,11 @@ describe('importVpatFromOpenAcr', () => {
   });
 
   it('creates only the criterion rows passed in (no auto-population)', async () => {
-    const project = await createProject({ name: 'Import Test 2' });
-    const codeMap = await getCriteriaByCode(['1.1.1', '1.4.3']);
+    const codeMap = await getCriteriaByCode(['1.1.1']);
     const criterionId = codeMap.get('1.1.1')!;
 
     const vpat = await importVpatFromOpenAcr({
-      project_id: project.id,
+      project_id: projectId,
       title: 'Sparse VPAT',
       description: null,
       standard_edition: 'WCAG',
@@ -388,9 +386,8 @@ describe('importVpatFromOpenAcr', () => {
   });
 
   it('creates a VPAT with zero rows when rows array is empty', async () => {
-    const project = await createProject({ name: 'Import Test 3' });
     const vpat = await importVpatFromOpenAcr({
-      project_id: project.id,
+      project_id: projectId,
       title: 'Empty VPAT',
       description: null,
       standard_edition: '508',

--- a/src/lib/db/criteria.ts
+++ b/src/lib/db/criteria.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import { getDbClient } from './client';
 import { criteria } from './schema';
@@ -227,4 +227,17 @@ export async function getCriteriaForEdition(
 export async function getCriterion(id: string): Promise<Criterion | null> {
   const rows = await db().select().from(criteria).where(eq(criteria.id, id)).limit(1);
   return rows[0] ? parseCriterion(rows[0] as CriterionDbRow) : null;
+}
+
+/**
+ * Returns a Map of criterion code → criterion id for the given codes.
+ * Codes not found in the criteria table are omitted from the result.
+ */
+export async function getCriteriaByCode(codes: string[]): Promise<Map<string, string>> {
+  if (codes.length === 0) return new Map();
+  const rows = await db()
+    .select({ id: criteria.id, code: criteria.code })
+    .from(criteria)
+    .where(inArray(criteria.code, codes));
+  return new Map(rows.map((r) => [r.code, r.id]));
 }

--- a/src/lib/db/vpats.ts
+++ b/src/lib/db/vpats.ts
@@ -222,6 +222,52 @@ export async function createVpat(input: CreateVpatParams): Promise<Vpat> {
   return (await getVpat(id))!;
 }
 
+export interface ImportVpatInput {
+  project_id: string;
+  title: string;
+  description: string | null;
+  standard_edition: 'WCAG' | '508' | 'EU' | 'INT';
+  wcag_version: '2.1' | '2.2';
+  wcag_level: 'A' | 'AA' | 'AAA';
+  rows: Array<{
+    criterion_id: string;
+    conformance:
+      | 'supports'
+      | 'partially_supports'
+      | 'does_not_support'
+      | 'not_applicable'
+      | 'not_evaluated';
+    remarks: string | null;
+  }>;
+}
+
+export async function importVpatFromOpenAcr(input: ImportVpatInput): Promise<Vpat> {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  db()
+    .insert(vpats)
+    .values({
+      id,
+      project_id: input.project_id,
+      title: input.title,
+      description: input.description,
+      standard_edition: input.standard_edition,
+      wcag_version: input.wcag_version,
+      wcag_level: input.wcag_level,
+      product_scope: JSON.stringify(['web']),
+      created_at: now,
+      updated_at: now,
+    })
+    .run();
+
+  if (input.rows.length > 0) {
+    createCriterionRows(id, input.rows);
+  }
+
+  return (await getVpat(id))!;
+}
+
 export async function updateVpat(id: string, input: UpdateVpatInput): Promise<Vpat | null> {
   const existing = await getVpat(id);
   if (!existing) return null;

--- a/src/lib/db/vpats.ts
+++ b/src/lib/db/vpats.ts
@@ -237,7 +237,7 @@ export interface ImportVpatInput {
       | 'does_not_support'
       | 'not_applicable'
       | 'not_evaluated';
-    remarks: string | null;
+    remarks?: string | null; // align with CreateCriterionRowInput
   }>;
 }
 
@@ -255,15 +255,13 @@ export async function importVpatFromOpenAcr(input: ImportVpatInput): Promise<Vpa
       standard_edition: input.standard_edition,
       wcag_version: input.wcag_version,
       wcag_level: input.wcag_level,
-      product_scope: JSON.stringify(['web']),
+      product_scope: JSON.stringify(['web']), // OpenACR YAML has no product_scope concept; default to web
       created_at: now,
       updated_at: now,
     })
     .run();
 
-  if (input.rows.length > 0) {
-    createCriterionRows(id, input.rows);
-  }
+  createCriterionRows(id, input.rows);
 
   return (await getVpat(id))!;
 }

--- a/src/lib/db/vpats.ts
+++ b/src/lib/db/vpats.ts
@@ -237,7 +237,7 @@ export interface ImportVpatInput {
       | 'does_not_support'
       | 'not_applicable'
       | 'not_evaluated';
-    remarks?: string | null; // align with CreateCriterionRowInput
+    remarks?: string | null;
   }>;
 }
 
@@ -261,7 +261,10 @@ export async function importVpatFromOpenAcr(input: ImportVpatInput): Promise<Vpa
     })
     .run();
 
-  createCriterionRows(id, input.rows);
+  createCriterionRows(
+    id,
+    input.rows.map((r) => ({ ...r, remarks: r.remarks ?? undefined }))
+  );
 
   return (await getVpat(id))!;
 }

--- a/src/lib/import/__tests__/parse-openacr.test.ts
+++ b/src/lib/import/__tests__/parse-openacr.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCatalog,
+  inferWcagLevel,
+  mapConformance,
+  extractCriteria,
+  parseOpenAcr,
+} from '../parse-openacr';
+
+describe('parseCatalog', () => {
+  it('resolves WCAG 2.1 catalog', () => {
+    const result = parseCatalog('2.4-edition-wcag-2.1-en');
+    expect(result).toEqual({ standard_edition: 'WCAG', wcag_version: '2.1' });
+  });
+
+  it('resolves WCAG 2.2 catalog', () => {
+    const result = parseCatalog('2.5-edition-wcag-2.2-en');
+    expect(result).toEqual({ standard_edition: 'WCAG', wcag_version: '2.2' });
+  });
+
+  it('resolves 508 catalog', () => {
+    const result = parseCatalog('2.4-edition-508-en');
+    expect(result).toEqual({ standard_edition: '508', wcag_version: '2.1' });
+  });
+
+  it('resolves EU catalog', () => {
+    const result = parseCatalog('2.4-edition-en301549-en');
+    expect(result).toEqual({ standard_edition: 'EU', wcag_version: '2.1' });
+  });
+
+  it('returns null for unknown catalog', () => {
+    expect(parseCatalog('unknown-catalog')).toBeNull();
+  });
+});
+
+describe('inferWcagLevel', () => {
+  it('returns AAA when level_aaa chapter present', () => {
+    expect(inferWcagLevel({ success_criteria_level_aaa: {}, success_criteria_level_aa: {} })).toBe(
+      'AAA'
+    );
+  });
+
+  it('returns AA when level_aa present but not aaa', () => {
+    expect(inferWcagLevel({ success_criteria_level_aa: {} })).toBe('AA');
+  });
+
+  it('returns A when only level_a present', () => {
+    expect(inferWcagLevel({ success_criteria_level_a: {} })).toBe('A');
+  });
+
+  it('returns A when no level chapters present', () => {
+    expect(inferWcagLevel({ hardware: {} })).toBe('A');
+  });
+});
+
+describe('mapConformance', () => {
+  it.each([
+    ['supports', 'supports'],
+    ['partially-supports', 'partially_supports'],
+    ['does-not-support', 'does_not_support'],
+    ['not-applicable', 'not_applicable'],
+    ['not-evaluated', 'not_evaluated'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(mapConformance(input)).toBe(expected);
+  });
+
+  it('returns not_evaluated for unknown values', () => {
+    expect(mapConformance('unknown')).toBe('not_evaluated');
+  });
+});
+
+describe('extractCriteria', () => {
+  const chapters = {
+    success_criteria_level_a: {
+      criteria: [
+        {
+          num: '1.1.1',
+          components: [
+            { name: 'web', adherence: { level: 'supports', notes: 'All images have alt text' } },
+          ],
+        },
+      ],
+    },
+    success_criteria_level_aa: {
+      criteria: [
+        {
+          num: '1.4.3',
+          components: [{ name: 'web', adherence: { level: 'partially-supports', notes: '' } }],
+        },
+      ],
+    },
+    hardware: { conformance: 'not-applicable' },
+  };
+
+  it('extracts criteria from all level chapters', () => {
+    const result = extractCriteria(chapters);
+    expect(result).toHaveLength(2);
+  });
+
+  it('maps criterion num to code', () => {
+    const result = extractCriteria(chapters);
+    expect(result[0]!.code).toBe('1.1.1');
+    expect(result[1]!.code).toBe('1.4.3');
+  });
+
+  it('maps conformance level', () => {
+    const result = extractCriteria(chapters);
+    expect(result[0]!.conformance).toBe('supports');
+    expect(result[1]!.conformance).toBe('partially_supports');
+  });
+
+  it('maps remarks, treating empty string as null', () => {
+    const result = extractCriteria(chapters);
+    expect(result[0]!.remarks).toBe('All images have alt text');
+    expect(result[1]!.remarks).toBeNull();
+  });
+
+  it('ignores non-criteria chapters (hardware, software, etc.)', () => {
+    const result = extractCriteria(chapters);
+    expect(result.every((c) => c.code !== 'hardware')).toBe(true);
+  });
+});
+
+describe('parseOpenAcr', () => {
+  const validDoc = {
+    title: 'My VPAT',
+    catalog: '2.4-edition-wcag-2.1-en',
+    notes: 'Test notes',
+    chapters: {
+      success_criteria_level_a: {
+        criteria: [
+          { num: '1.1.1', components: [{ adherence: { level: 'supports', notes: 'Good' } }] },
+        ],
+      },
+    },
+  };
+
+  it('parses a valid OpenACR document', () => {
+    const result = parseOpenAcr(validDoc);
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('My VPAT');
+    expect(result!.description).toBe('Test notes');
+    expect(result!.standard_edition).toBe('WCAG');
+    expect(result!.wcag_version).toBe('2.1');
+    expect(result!.wcag_level).toBe('A');
+    expect(result!.criteria).toHaveLength(1);
+  });
+
+  it('returns null when catalog is missing', () => {
+    expect(parseOpenAcr({ title: 'X', chapters: {} })).toBeNull();
+  });
+
+  it('returns null when chapters is missing', () => {
+    expect(parseOpenAcr({ title: 'X', catalog: '2.4-edition-wcag-2.1-en' })).toBeNull();
+  });
+
+  it('returns null for unknown catalog', () => {
+    expect(parseOpenAcr({ title: 'X', catalog: 'bad-catalog', chapters: {} })).toBeNull();
+  });
+
+  it('returns null for non-object input', () => {
+    expect(parseOpenAcr(null)).toBeNull();
+    expect(parseOpenAcr('string')).toBeNull();
+  });
+
+  it('uses empty string notes as null description', () => {
+    const result = parseOpenAcr({ ...validDoc, notes: '' });
+    expect(result!.description).toBeNull();
+  });
+});

--- a/src/lib/import/parse-openacr.ts
+++ b/src/lib/import/parse-openacr.ts
@@ -1,0 +1,97 @@
+export interface OpenAcrParseResult {
+  title: string;
+  description: string | null;
+  standard_edition: 'WCAG' | '508' | 'EU' | 'INT';
+  wcag_version: '2.1' | '2.2';
+  wcag_level: 'A' | 'AA' | 'AAA';
+  criteria: Array<{ code: string; conformance: string; remarks: string | null }>;
+}
+
+const CATALOG_MAP: Record<
+  string,
+  { standard_edition: 'WCAG' | '508' | 'EU' | 'INT'; wcag_version: '2.1' | '2.2' }
+> = {
+  '2.4-edition-wcag-2.1-en': { standard_edition: 'WCAG', wcag_version: '2.1' },
+  '2.5-edition-wcag-2.2-en': { standard_edition: 'WCAG', wcag_version: '2.2' },
+  '2.4-edition-wcag-2.2-en': { standard_edition: 'WCAG', wcag_version: '2.2' },
+  '2.4-edition-508-en': { standard_edition: '508', wcag_version: '2.1' },
+  '2.5-edition-wcag-2.2-508-en': { standard_edition: '508', wcag_version: '2.2' },
+  '2.4-edition-en301549-en': { standard_edition: 'EU', wcag_version: '2.1' },
+  '2.5-edition-wcag-2.2-en301549-en': { standard_edition: 'EU', wcag_version: '2.2' },
+};
+
+const CONFORMANCE_MAP: Record<string, string> = {
+  supports: 'supports',
+  'partially-supports': 'partially_supports',
+  'does-not-support': 'does_not_support',
+  'not-applicable': 'not_applicable',
+  'not-evaluated': 'not_evaluated',
+};
+
+export function parseCatalog(
+  catalogId: string
+): { standard_edition: 'WCAG' | '508' | 'EU' | 'INT'; wcag_version: '2.1' | '2.2' } | null {
+  return CATALOG_MAP[catalogId] ?? null;
+}
+
+export function inferWcagLevel(chapters: Record<string, unknown>): 'A' | 'AA' | 'AAA' {
+  if ('success_criteria_level_aaa' in chapters) return 'AAA';
+  if ('success_criteria_level_aa' in chapters) return 'AA';
+  return 'A';
+}
+
+export function mapConformance(level: string): string {
+  return CONFORMANCE_MAP[level] ?? 'not_evaluated';
+}
+
+export function extractCriteria(
+  chapters: Record<string, unknown>
+): Array<{ code: string; conformance: string; remarks: string | null }> {
+  const result: Array<{ code: string; conformance: string; remarks: string | null }> = [];
+  const levelKeys = [
+    'success_criteria_level_a',
+    'success_criteria_level_aa',
+    'success_criteria_level_aaa',
+  ];
+
+  for (const key of levelKeys) {
+    const chapter = chapters[key] as { criteria?: unknown[] } | undefined;
+    if (!chapter?.criteria) continue;
+
+    for (const entry of chapter.criteria) {
+      const c = entry as {
+        num: string;
+        components?: Array<{ adherence?: { level?: string; notes?: string } }>;
+      };
+      const adherence = c.components?.[0]?.adherence;
+      const notes = adherence?.notes ?? '';
+      result.push({
+        code: c.num,
+        conformance: mapConformance(adherence?.level ?? 'not-evaluated'),
+        remarks: notes.trim() ? notes : null,
+      });
+    }
+  }
+
+  return result;
+}
+
+export function parseOpenAcr(raw: unknown): OpenAcrParseResult | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const doc = raw as Record<string, unknown>;
+  if (!doc.catalog || !doc.chapters) return null;
+
+  const catalogInfo = parseCatalog(doc.catalog as string);
+  if (!catalogInfo) return null;
+
+  const chapters = doc.chapters as Record<string, unknown>;
+  const notes = (doc.notes as string) ?? '';
+
+  return {
+    title: (doc.title as string) || 'Untitled VPAT',
+    description: notes.trim() ? notes : null,
+    ...catalogInfo,
+    wcag_level: inferWcagLevel(chapters),
+    criteria: extractCriteria(chapters),
+  };
+}

--- a/src/lib/import/parse-openacr.ts
+++ b/src/lib/import/parse-openacr.ts
@@ -1,10 +1,17 @@
+export type ConformanceLevel =
+  | 'supports'
+  | 'partially_supports'
+  | 'does_not_support'
+  | 'not_applicable'
+  | 'not_evaluated';
+
 export interface OpenAcrParseResult {
   title: string;
   description: string | null;
   standard_edition: 'WCAG' | '508' | 'EU' | 'INT';
   wcag_version: '2.1' | '2.2';
   wcag_level: 'A' | 'AA' | 'AAA';
-  criteria: Array<{ code: string; conformance: string; remarks: string | null }>;
+  criteria: Array<{ code: string; conformance: ConformanceLevel; remarks: string | null }>;
 }
 
 const CATALOG_MAP: Record<
@@ -20,7 +27,7 @@ const CATALOG_MAP: Record<
   '2.5-edition-wcag-2.2-en301549-en': { standard_edition: 'EU', wcag_version: '2.2' },
 };
 
-const CONFORMANCE_MAP: Record<string, string> = {
+const CONFORMANCE_MAP: Record<string, ConformanceLevel> = {
   supports: 'supports',
   'partially-supports': 'partially_supports',
   'does-not-support': 'does_not_support',
@@ -40,14 +47,14 @@ export function inferWcagLevel(chapters: Record<string, unknown>): 'A' | 'AA' | 
   return 'A';
 }
 
-export function mapConformance(level: string): string {
+export function mapConformance(level: string): ConformanceLevel {
   return CONFORMANCE_MAP[level] ?? 'not_evaluated';
 }
 
 export function extractCriteria(
   chapters: Record<string, unknown>
-): Array<{ code: string; conformance: string; remarks: string | null }> {
-  const result: Array<{ code: string; conformance: string; remarks: string | null }> = [];
+): Array<{ code: string; conformance: ConformanceLevel; remarks: string | null }> {
+  const result: Array<{ code: string; conformance: ConformanceLevel; remarks: string | null }> = [];
   const levelKeys = [
     'success_criteria_level_a',
     'success_criteria_level_aa',


### PR DESCRIPTION

### Description

This pull request introduces the ability to import VPAT data from OpenACR YAML files. It includes the following changes:

- **Features**:
  - Added `Import from OpenACR` button to the VPAT list for triggering imports.
  - Implemented a `Generate All` progress modal to display per-criterion updates during import.
  - Added the `ImportOpenAcrModal` component for file upload and import functionality.
  - Added a utility to parse OpenACR YAML and implemented a new import API route.
  - Created `getCriteriaByCode` for efficient bulk criterion lookup.
  - Introduced `importVpatFromOpenAcr` to handle VPAT imports and skip auto-population.

- **Fixes**:
  - Ensured `null` remarks in import data are coerced to `undefined`, aligning with stricter input type requirements.
  - Tightened conformance types and introduced error handling for the import route.
  - Adjusted type definitions and cleaned up existing import-related tests.

- **Tests**:
  - Added end-to-end tests to cover the OpenACR YAML import workflow.

These updates enhance the VPAT management process by supporting YAML import, improving error handling, and offering better type safety.

---

### Checklist

- [ ] The pull request's title is descriptive.
- [ ] The feature or fix has corresponding tests.
- [ ] Documentation has been added or updated where applicable.
- [ ] All code builds and passes linting/tests successfully.