### PR TITLE
Add snapshot history for VPATs

### DIFF
--- a/migrations/010_vpat_snapshots.sql
+++ b/migrations/010_vpat_snapshots.sql
@@ -1,0 +1,9 @@
+CREATE TABLE vpat_snapshots (
+  id TEXT PRIMARY KEY,
+  vpat_id TEXT NOT NULL REFERENCES vpats(id) ON DELETE CASCADE,
+  version_number INTEGER NOT NULL,
+  published_at TEXT NOT NULL,
+  snapshot TEXT NOT NULL
+);
+
+CREATE INDEX idx_vpat_snapshots_vpat_id ON vpat_snapshots(vpat_id);

--- a/src/app/(app)/vpats/[id]/page.tsx
+++ b/src/app/(app)/vpats/[id]/page.tsx
@@ -14,7 +14,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Download, ChevronDown } from 'lucide-react';
+import { Download, ChevronDown, History } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { VpatCriteriaTable } from '@/components/vpats/vpat-criteria-table';
 import { VpatIssuesPanel, type PanelIssue } from '@/components/vpats/vpat-issues-panel';
 import { DeleteVpatButton } from '@/components/vpats/delete-vpat-button';
@@ -60,6 +61,9 @@ export default function VpatDetailPage() {
   const [generateProgress, setGenerateProgress] = useState(0);
   const [generateTotal, setGenerateTotal] = useState(0);
   const [isGeneratingAll, setIsGeneratingAll] = useState(false);
+  const [snapshots, setSnapshots] = useState<
+    { id: string; version_number: number; published_at: string }[]
+  >([]);
 
   useEffect(() => {
     async function load() {
@@ -73,6 +77,14 @@ export default function VpatDetailPage() {
         }
         setVpat(json.data);
         setRows(json.data.criterion_rows);
+        // Load version history
+        try {
+          const snapRes = await fetch(`/api/vpats/${vpatId}/versions`);
+          const snapJson = await snapRes.json();
+          if (snapJson.success) setSnapshots(snapJson.data);
+        } catch {
+          // non-fatal — version history tab shows empty state
+        }
       } catch {
         toast.error('Failed to load VPAT');
         router.push('/vpats');
@@ -223,6 +235,14 @@ export default function VpatDetailPage() {
         return;
       }
       setVpat(json.data);
+      // Refresh snapshots after publish
+      try {
+        const snapRes = await fetch(`/api/vpats/${vpatId}/versions`);
+        const snapJson = await snapRes.json();
+        if (snapJson.success) setSnapshots(snapJson.data);
+      } catch {
+        // non-fatal
+      }
       toast.success('VPAT published');
     } catch {
       toast.error('Failed to publish');
@@ -300,34 +320,87 @@ export default function VpatDetailPage() {
         </div>
       </div>
 
-      {/* Progress */}
-      <Card>
-        <CardContent className="pt-4">
-          <p className="text-sm font-medium">
-            {resolved} of {total} criteria resolved
-          </p>
-          <div className="mt-2 h-2 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full bg-primary transition-all"
-              style={{ width: total > 0 ? `${(resolved / total) * 100}%` : '0%' }}
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <Tabs defaultValue="criteria">
+        <TabsList>
+          <TabsTrigger value="criteria">Criteria</TabsTrigger>
+          <TabsTrigger value="history">
+            <History className="mr-1 h-4 w-4" />
+            Version History
+            {snapshots.length > 0 && (
+              <span className="ml-1 text-xs text-muted-foreground">({snapshots.length})</span>
+            )}
+          </TabsTrigger>
+        </TabsList>
 
-      {/* Criteria Table — key resets RHF defaults after generate-all */}
-      <VpatCriteriaTable
-        key={tableKey}
-        rows={rows}
-        onRowChange={handleRowChange}
-        onSaveRemarks={handleSaveRemarks}
-        onGenerateRow={handleGenerateRow}
-        onGenerateAll={handleGenerateAll}
-        generatingRowId={generatingRowId}
-        readOnly={isPublished}
-        aiEnabled={true}
-        onCriterionClick={handleCriterionClick}
-      />
+        <TabsContent value="criteria" className="space-y-6">
+          {/* Progress */}
+          <Card>
+            <CardContent className="pt-4">
+              <p className="text-sm font-medium">
+                {resolved} of {total} criteria resolved
+              </p>
+              <div className="mt-2 h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  className="h-full bg-primary transition-all"
+                  style={{ width: total > 0 ? `${(resolved / total) * 100}%` : '0%' }}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Criteria Table — key resets RHF defaults after generate-all */}
+          <VpatCriteriaTable
+            key={tableKey}
+            rows={rows}
+            onRowChange={handleRowChange}
+            onSaveRemarks={handleSaveRemarks}
+            onGenerateRow={handleGenerateRow}
+            onGenerateAll={handleGenerateAll}
+            generatingRowId={generatingRowId}
+            readOnly={isPublished}
+            aiEnabled={true}
+            onCriterionClick={handleCriterionClick}
+          />
+        </TabsContent>
+
+        <TabsContent value="history">
+          {snapshots.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4">
+              No published versions yet. Publish this VPAT to create a snapshot.
+            </p>
+          ) : (
+            <div className="rounded-md border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="px-4 py-2 text-left font-medium">Version</th>
+                    <th className="px-4 py-2 text-left font-medium">Published</th>
+                    <th className="px-4 py-2 text-right font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snapshots.map((snap) => (
+                    <tr key={snap.id} className="border-b last:border-0">
+                      <td className="px-4 py-2">v{snap.version_number}</td>
+                      <td className="px-4 py-2 text-muted-foreground">
+                        {new Date(snap.published_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-2 text-right">
+                        <a
+                          href={`/vpats/${vpatId}/versions/${snap.version_number}`}
+                          className="text-sm font-medium underline-offset-4 hover:underline"
+                        >
+                          View
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
 
       {/* Generate All progress modal */}
       <Dialog open={isGeneratingAll}>

--- a/src/app/(app)/vpats/[id]/versions/[version]/page.tsx
+++ b/src/app/(app)/vpats/[id]/versions/[version]/page.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Breadcrumbs } from '@/components/ui/breadcrumbs';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Download, ChevronDown, ArrowLeft } from 'lucide-react';
+import { VpatCriteriaTable } from '@/components/vpats/vpat-criteria-table';
+import type { VpatCriterionRow } from '@/lib/db/vpat-criterion-rows';
+import type { VpatSnapshotData } from '@/lib/db/vpat-snapshots';
+
+interface SnapshotResponse {
+  version_number: number;
+  published_at: string;
+  vpat: VpatSnapshotData;
+}
+
+export default function VpatVersionPage() {
+  const params = useParams<{ id: string; version: string }>();
+  const router = useRouter();
+  const { id: vpatId, version } = params;
+
+  const [snapshot, setSnapshot] = useState<SnapshotResponse | null>(null);
+  const [rows, setRows] = useState<VpatCriterionRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/vpats/${vpatId}/versions/${version}`);
+        const json = await res.json();
+        if (!json.success) {
+          toast.error('Version not found');
+          router.push(`/vpats/${vpatId}`);
+          return;
+        }
+        setSnapshot(json.data);
+        // Convert snapshot criterion_rows to VpatCriterionRow shape for the table
+        const snapshotRows: VpatCriterionRow[] = json.data.vpat.criterion_rows.map(
+          (r: VpatSnapshotData['criterion_rows'][0], i: number) => ({
+            id: `snap-${i}`,
+            vpat_id: vpatId,
+            criterion_id: `snap-${i}`,
+            criterion_code: r.criterion_code,
+            criterion_name: r.criterion_name,
+            criterion_description: r.criterion_description,
+            criterion_level: r.criterion_level,
+            criterion_section: r.criterion_section,
+            conformance: r.conformance as VpatCriterionRow['conformance'],
+            remarks: r.remarks,
+            ai_confidence: null,
+            ai_reasoning: null,
+            last_generated_at: null,
+            updated_at: json.data.published_at,
+            issue_count: 0,
+          })
+        );
+        setRows(snapshotRows);
+      } catch {
+        toast.error('Failed to load version');
+        router.push(`/vpats/${vpatId}`);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    load();
+  }, [vpatId, version, router]);
+
+  if (isLoading) return <div className="text-muted-foreground text-sm p-6">Loading…</div>;
+  if (!snapshot) return null;
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumbs
+        items={[
+          { label: 'VPATs', href: '/vpats' },
+          { label: 'VPAT Detail', href: `/vpats/${vpatId}` },
+          { label: `Version ${snapshot.version_number}` },
+        ]}
+      />
+
+      {/* Read-only banner */}
+      <div className="flex items-center gap-3 rounded-md border border-muted bg-muted/30 px-4 py-2 text-sm text-muted-foreground">
+        <span>
+          <strong>Version {snapshot.version_number}</strong> — Published{' '}
+          {new Date(snapshot.published_at).toLocaleDateString()}
+        </span>
+        <span>·</span>
+        <span>This is a historical snapshot.</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto"
+          onClick={() => router.push(`/vpats/${vpatId}`)}
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to current VPAT
+        </Button>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold">{snapshot.vpat.title}</h1>
+          <div className="flex items-center gap-2">
+            <Badge variant="outline">v{snapshot.version_number}</Badge>
+            <Badge variant="default">Published</Badge>
+          </div>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm">
+              <Download className="mr-2 h-4 w-4" />
+              Export
+              <ChevronDown className="ml-1 h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild>
+              <a href={`/api/vpats/${vpatId}/versions/${version}/export?format=docx`}>
+                Word (.docx)
+              </a>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <a href={`/api/vpats/${vpatId}/versions/${version}/export?format=openacr`}>
+                OpenACR (YAML)
+              </a>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Read-only criteria table */}
+      <VpatCriteriaTable
+        rows={rows}
+        onRowChange={async () => {}}
+        onSaveRemarks={async () => {}}
+        onGenerateRow={async () => {}}
+        onGenerateAll={async () => {}}
+        generatingRowId={null}
+        readOnly={true}
+        aiEnabled={false}
+        onCriterionClick={() => {}}
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/vpats/__tests__/edit-page.test.tsx
+++ b/src/app/(app)/vpats/__tests__/edit-page.test.tsx
@@ -60,7 +60,7 @@ const mockVpat = {
 beforeEach(() => {
   vi.spyOn(global, 'fetch').mockImplementation((input) => {
     const url = typeof input === 'string' ? input : (input as Request).url;
-    if (url.includes('/api/issues/by-criterion')) {
+    if (url.includes('/api/issues/by-criterion') || url.includes('/versions')) {
       return Promise.resolve({
         ok: true,
         json: async () => ({ success: true, data: [] }),

--- a/src/app/api/vpats/[id]/versions/[version]/__tests__/route.test.ts
+++ b/src/app/api/vpats/[id]/versions/[version]/__tests__/route.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { createVpat, publishVpat } from '@/lib/db/vpats';
+import { GET } from '../route';
+
+let projectId: string;
+let vpatId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(async () => {
+  getDb().prepare('DELETE FROM vpat_snapshots').run();
+  getDb().prepare('DELETE FROM vpat_criterion_rows').run();
+  getDb().prepare('DELETE FROM vpats').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = await createProject({ name: 'Test Project' });
+  projectId = project.id;
+  const vpat = await createVpat({
+    title: 'Test VPAT',
+    project_id: projectId,
+    standard_edition: 'WCAG',
+    wcag_version: '2.1',
+    wcag_level: 'AA',
+    product_scope: ['web'],
+  });
+  vpatId = vpat.id;
+  getDb()
+    .prepare("UPDATE vpat_criterion_rows SET conformance = 'supports' WHERE vpat_id = ?")
+    .run(vpatId);
+});
+
+function makeContext(id: string, version: string) {
+  return { params: Promise.resolve({ id, version }) };
+}
+
+describe('GET /api/vpats/[id]/versions/[version]', () => {
+  it('returns the snapshot for a published version', async () => {
+    await publishVpat(vpatId);
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions/2`),
+      makeContext(vpatId, '2')
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.version_number).toBe(2);
+    expect(body.data.published_at).toBeDefined();
+    expect(body.data.vpat.title).toBe('Test VPAT');
+    expect(Array.isArray(body.data.vpat.criterion_rows)).toBe(true);
+  });
+
+  it('returns 404 for nonexistent version', async () => {
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions/99`),
+      makeContext(vpatId, '99')
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 for non-numeric version', async () => {
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions/abc`),
+      makeContext(vpatId, 'abc')
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('BAD_REQUEST');
+  });
+
+  it('returns 404 for nonexistent VPAT', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/vpats/nonexistent/versions/2'),
+      makeContext('nonexistent', '2')
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+});

--- a/src/app/api/vpats/[id]/versions/[version]/export/__tests__/route.test.ts
+++ b/src/app/api/vpats/[id]/versions/[version]/export/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { createVpat, publishVpat } from '@/lib/db/vpats';
+import { GET } from '../route';
+
+let projectId: string;
+let vpatId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(async () => {
+  getDb().prepare('DELETE FROM vpat_snapshots').run();
+  getDb().prepare('DELETE FROM vpat_criterion_rows').run();
+  getDb().prepare('DELETE FROM vpats').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = await createProject({ name: 'Test Project' });
+  projectId = project.id;
+  const vpat = await createVpat({
+    title: 'Export Test',
+    project_id: projectId,
+    standard_edition: 'WCAG',
+    wcag_version: '2.1',
+    wcag_level: 'AA',
+    product_scope: ['web'],
+  });
+  vpatId = vpat.id;
+  getDb()
+    .prepare("UPDATE vpat_criterion_rows SET conformance = 'supports' WHERE vpat_id = ?")
+    .run(vpatId);
+  await publishVpat(vpatId);
+});
+
+function makeContext(id: string, version: string) {
+  return { params: Promise.resolve({ id, version }) };
+}
+
+describe('GET /api/vpats/[id]/versions/[version]/export', () => {
+  it('returns openacr YAML for a snapshot version', async () => {
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions/2/export?format=openacr`),
+      makeContext(vpatId, '2')
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('yaml');
+  });
+
+  it('returns docx for a snapshot version', async () => {
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions/2/export?format=docx`),
+      makeContext(vpatId, '2')
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('wordprocessingml');
+  });
+
+  it('returns 404 for nonexistent version', async () => {
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions/99/export?format=openacr`),
+      makeContext(vpatId, '99')
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for unsupported format', async () => {
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions/2/export?format=pdf`),
+      makeContext(vpatId, '2')
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('BAD_REQUEST');
+  });
+});

--- a/src/app/api/vpats/[id]/versions/[version]/export/route.ts
+++ b/src/app/api/vpats/[id]/versions/[version]/export/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server';
+import { getVpat } from '@/lib/db/vpats';
+import { getProject } from '@/lib/db/projects';
+import { getVpatSnapshot } from '@/lib/db/vpat-snapshots';
+import { generateVpatDocx } from '@/lib/export/vpat-docx';
+import { generateOpenAcrYaml } from '@/lib/export/openacr';
+import type { VpatCriterionRow } from '@/lib/db/vpat-criterion-rows';
+import type { Vpat } from '@/lib/db/vpats';
+
+type RouteContext = { params: Promise<{ id: string; version: string }> };
+
+const SUPPORTED_FORMATS = ['docx', 'openacr'] as const;
+type SupportedFormat = (typeof SUPPORTED_FORMATS)[number];
+
+function safeTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+}
+
+export async function GET(request: Request, { params }: RouteContext) {
+  const { id, version } = await params;
+  const url = new URL(request.url);
+  const format = url.searchParams.get('format') ?? '';
+
+  if (!(SUPPORTED_FORMATS as readonly string[]).includes(format)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: `Unsupported format "${format}". Supported formats for snapshots: docx, openacr`,
+        code: 'BAD_REQUEST',
+      },
+      { status: 400 }
+    );
+  }
+
+  const versionNum = parseInt(version, 10);
+  if (isNaN(versionNum)) {
+    return NextResponse.json(
+      { success: false, error: 'Version must be a number', code: 'BAD_REQUEST' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const vpat = await getVpat(id);
+    if (!vpat) {
+      return NextResponse.json(
+        { success: false, error: 'VPAT not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+    const snapshot = await getVpatSnapshot(id, versionNum);
+    if (!snapshot) {
+      return NextResponse.json(
+        { success: false, error: 'Version not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+    const project = await getProject(vpat.project_id);
+    if (!project) {
+      return NextResponse.json(
+        { success: false, error: 'Project not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    }
+
+    // Reconstruct a Vpat-shaped object from snapshot metadata
+    const snapshotVpat: Vpat = {
+      ...vpat,
+      title: snapshot.data.title,
+      description: snapshot.data.description,
+      standard_edition: snapshot.data.standard_edition as Vpat['standard_edition'],
+      wcag_version: snapshot.data.wcag_version as Vpat['wcag_version'],
+      wcag_level: snapshot.data.wcag_level as Vpat['wcag_level'],
+      product_scope: snapshot.data.product_scope,
+      version_number: snapshot.version_number,
+      published_at: snapshot.published_at,
+      status: 'published',
+    };
+
+    // Reconstruct VpatCriterionRow[] from snapshot rows (fake IDs, AI fields null)
+    const rows: VpatCriterionRow[] = snapshot.data.criterion_rows.map((r, i) => ({
+      id: `snap-${i}`,
+      vpat_id: id,
+      criterion_id: `snap-${i}`,
+      criterion_code: r.criterion_code,
+      criterion_name: r.criterion_name,
+      criterion_description: r.criterion_description,
+      criterion_level: r.criterion_level,
+      criterion_section: r.criterion_section,
+      conformance: r.conformance as VpatCriterionRow['conformance'],
+      remarks: r.remarks,
+      ai_confidence: null,
+      ai_reasoning: null,
+      last_generated_at: null,
+      updated_at: snapshot.published_at,
+      issue_count: 0,
+    }));
+
+    const slug = safeTitle(snapshot.data.title);
+
+    if ((format as SupportedFormat) === 'docx') {
+      const buffer = await generateVpatDocx(snapshotVpat, project, rows);
+      return new Response(new Uint8Array(buffer), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          'Content-Disposition': `attachment; filename="vpat-v${versionNum}-${slug}.docx"`,
+        },
+      });
+    }
+
+    // openacr
+    const yaml = generateOpenAcrYaml(snapshotVpat, project, rows);
+    return new Response(yaml, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/yaml',
+        'Content-Disposition': `attachment; filename="vpat-v${versionNum}-${slug}.yaml"`,
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Failed to generate export', code: 'INTERNAL_ERROR' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/vpats/[id]/versions/[version]/route.ts
+++ b/src/app/api/vpats/[id]/versions/[version]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getVpat } from '@/lib/db/vpats';
+import { getVpatSnapshot } from '@/lib/db/vpat-snapshots';
+
+type RouteContext = { params: Promise<{ id: string; version: string }> };
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { id, version } = await params;
+  const versionNum = parseInt(version, 10);
+  if (isNaN(versionNum)) {
+    return NextResponse.json(
+      { success: false, error: 'Version must be a number', code: 'BAD_REQUEST' },
+      { status: 400 }
+    );
+  }
+  const vpat = await getVpat(id);
+  if (!vpat) {
+    return NextResponse.json(
+      { success: false, error: 'VPAT not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+  const snapshot = await getVpatSnapshot(id, versionNum);
+  if (!snapshot) {
+    return NextResponse.json(
+      { success: false, error: 'Version not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json({
+    success: true,
+    data: {
+      version_number: snapshot.version_number,
+      published_at: snapshot.published_at,
+      vpat: snapshot.data,
+    },
+  });
+}

--- a/src/app/api/vpats/[id]/versions/__tests__/route.test.ts
+++ b/src/app/api/vpats/[id]/versions/__tests__/route.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb, getDb } from '@/lib/db/index';
+import { createProject } from '@/lib/db/projects';
+import { createVpat, publishVpat } from '@/lib/db/vpats';
+import { GET } from '../route';
+
+let projectId: string;
+let vpatId: string;
+
+beforeAll(() => {
+  initDb(':memory:');
+});
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(async () => {
+  getDb().prepare('DELETE FROM vpat_snapshots').run();
+  getDb().prepare('DELETE FROM vpat_criterion_rows').run();
+  getDb().prepare('DELETE FROM vpats').run();
+  getDb().prepare('DELETE FROM projects').run();
+  const project = await createProject({ name: 'Test Project' });
+  projectId = project.id;
+  const vpat = await createVpat({
+    title: 'Test VPAT',
+    project_id: projectId,
+    standard_edition: 'WCAG',
+    wcag_version: '2.1',
+    wcag_level: 'AA',
+    product_scope: ['web'],
+  });
+  vpatId = vpat.id;
+  // Resolve all rows so publish can succeed
+  getDb()
+    .prepare("UPDATE vpat_criterion_rows SET conformance = 'supports' WHERE vpat_id = ?")
+    .run(vpatId);
+});
+
+function makeContext(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe('GET /api/vpats/[id]/versions', () => {
+  it('returns empty array when no snapshots exist', async () => {
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions`),
+      makeContext(vpatId)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([]);
+  });
+
+  it('returns snapshot list after publishing', async () => {
+    await publishVpat(vpatId);
+    const res = await GET(
+      new Request(`http://localhost/api/vpats/${vpatId}/versions`),
+      makeContext(vpatId)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].version_number).toBe(2);
+    expect(body.data[0].published_at).toBeDefined();
+    expect(body.data[0].snapshot).toBeUndefined(); // blob not included
+  });
+
+  it('returns 404 for nonexistent VPAT', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/vpats/nonexistent/versions'),
+      makeContext('nonexistent')
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+});

--- a/src/app/api/vpats/[id]/versions/route.ts
+++ b/src/app/api/vpats/[id]/versions/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getVpat } from '@/lib/db/vpats';
+import { listVpatSnapshots } from '@/lib/db/vpat-snapshots';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { id } = await params;
+  const vpat = await getVpat(id);
+  if (!vpat) {
+    return NextResponse.json(
+      { success: false, error: 'VPAT not found', code: 'NOT_FOUND' },
+      { status: 404 }
+    );
+  }
+  const snapshots = await listVpatSnapshots(id);
+  return NextResponse.json({ success: true, data: snapshots });
+}

--- a/src/lib/db/__tests__/schema.test.ts
+++ b/src/lib/db/__tests__/schema.test.ts
@@ -4,6 +4,7 @@ import Database from 'better-sqlite3';
 import { runMigrations } from '../migrate';
 import { loadMigrations } from '../load-migrations';
 import path from 'path';
+import * as schema from '../schema';
 
 interface TableInfo {
   cid: number;
@@ -246,6 +247,17 @@ describe('core tables schema', () => {
     it('has a foreign key to criteria', () => {
       const fks = getForeignKeys(db, 'vpat_criterion_rows');
       expect(fks.some((fk) => fk.table === 'criteria' && fk.from === 'criterion_id')).toBe(true);
+    });
+  });
+
+  describe('vpat_snapshots', () => {
+    it('has the correct columns', () => {
+      const columns = getColumnNames(db, 'vpat_snapshots');
+      expect(columns).toEqual(['id', 'vpat_id', 'version_number', 'published_at', 'snapshot']);
+    });
+
+    it('includes vpat_snapshots table', () => {
+      expect(schema.vpatSnapshots).toBeDefined();
     });
   });
 

--- a/src/lib/db/__tests__/vpat-snapshots.test.ts
+++ b/src/lib/db/__tests__/vpat-snapshots.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { initDb, closeDb } from '../index';
+import { getDbClient } from '../client';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type * as sqliteSchema from '../schema';
+import * as schema from '../schema';
+import { createProject } from '../projects';
+import { createVpat } from '../vpats';
+import { createVpatSnapshot, listVpatSnapshots, getVpatSnapshot } from '../vpat-snapshots';
+
+function dbc() {
+  return getDbClient() as BetterSQLite3Database<typeof sqliteSchema>;
+}
+
+let projectId: string;
+let vpatId: string;
+
+beforeAll(async () => {
+  await initDb(':memory:');
+});
+afterAll(() => {
+  closeDb();
+});
+
+beforeEach(async () => {
+  await dbc().delete(schema.vpatSnapshots);
+  await dbc().delete(schema.vpatCriterionRows);
+  await dbc().delete(schema.vpats);
+  await dbc().delete(schema.projects);
+  projectId = (await createProject({ name: 'Test Project' })).id;
+  const vpat = await createVpat({
+    title: 'Test VPAT',
+    project_id: projectId,
+    standard_edition: 'WCAG',
+    wcag_version: '2.1',
+    wcag_level: 'AA',
+    product_scope: ['web'],
+  });
+  vpatId = vpat.id;
+});
+
+describe('createVpatSnapshot', () => {
+  it('stores a snapshot and returns it', async () => {
+    const snap = await createVpatSnapshot(vpatId, 2, new Date().toISOString(), {
+      title: 'Test VPAT',
+      description: null,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web'],
+      criterion_rows: [
+        {
+          criterion_code: '1.1.1',
+          criterion_name: 'Non-text Content',
+          criterion_description: 'desc',
+          criterion_level: 'A',
+          criterion_section: '1.1',
+          conformance: 'supports',
+          remarks: null,
+        },
+      ],
+    });
+    expect(snap.id).toBeDefined();
+    expect(snap.version_number).toBe(2);
+    expect(snap.vpat_id).toBe(vpatId);
+  });
+});
+
+describe('listVpatSnapshots', () => {
+  it('returns snapshots ordered by version_number descending', async () => {
+    const now = new Date().toISOString();
+    const data = {
+      title: 'T',
+      description: null,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web'],
+      criterion_rows: [],
+    };
+    await createVpatSnapshot(vpatId, 1, now, data);
+    await createVpatSnapshot(vpatId, 2, now, data);
+    const list = await listVpatSnapshots(vpatId);
+    expect(list).toHaveLength(2);
+    expect(list[0].version_number).toBe(2);
+    expect(list[1].version_number).toBe(1);
+    // Should NOT include the snapshot blob
+    expect((list[0] as Record<string, unknown>).snapshot).toBeUndefined();
+  });
+});
+
+describe('getVpatSnapshot', () => {
+  it('returns the full deserialized snapshot for a version', async () => {
+    const now = new Date().toISOString();
+    const data = {
+      title: 'Test VPAT',
+      description: null,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web'],
+      criterion_rows: [],
+    };
+    await createVpatSnapshot(vpatId, 2, now, data);
+    const snap = await getVpatSnapshot(vpatId, 2);
+    expect(snap).not.toBeNull();
+    expect(snap!.version_number).toBe(2);
+    expect(snap!.data.title).toBe('Test VPAT');
+    expect(snap!.data.criterion_rows).toEqual([]);
+  });
+
+  it('returns null for a version that does not exist', async () => {
+    const snap = await getVpatSnapshot(vpatId, 99);
+    expect(snap).toBeNull();
+  });
+});

--- a/src/lib/db/__tests__/vpat-snapshots.test.ts
+++ b/src/lib/db/__tests__/vpat-snapshots.test.ts
@@ -83,10 +83,10 @@ describe('listVpatSnapshots', () => {
     await createVpatSnapshot(vpatId, 2, now, data);
     const list = await listVpatSnapshots(vpatId);
     expect(list).toHaveLength(2);
-    expect(list[0].version_number).toBe(2);
-    expect(list[1].version_number).toBe(1);
+    expect(list[0]!.version_number).toBe(2);
+    expect(list[1]!.version_number).toBe(1);
     // Should NOT include the snapshot blob
-    expect((list[0] as unknown as Record<string, unknown>).snapshot).toBeUndefined();
+    expect((list[0]! as unknown as Record<string, unknown>).snapshot).toBeUndefined();
   });
 });
 

--- a/src/lib/db/__tests__/vpat-snapshots.test.ts
+++ b/src/lib/db/__tests__/vpat-snapshots.test.ts
@@ -86,7 +86,7 @@ describe('listVpatSnapshots', () => {
     expect(list[0].version_number).toBe(2);
     expect(list[1].version_number).toBe(1);
     // Should NOT include the snapshot blob
-    expect((list[0] as Record<string, unknown>).snapshot).toBeUndefined();
+    expect((list[0] as unknown as Record<string, unknown>).snapshot).toBeUndefined();
   });
 });
 

--- a/src/lib/db/__tests__/vpats.test.ts
+++ b/src/lib/db/__tests__/vpats.test.ts
@@ -19,6 +19,8 @@ import {
 } from '../vpats';
 import { getCriterionRows } from '../vpat-criterion-rows';
 import { getCriteriaByCode } from '../criteria';
+import { listVpatSnapshots } from '../vpat-snapshots';
+import { eq } from 'drizzle-orm';
 
 function dbc() {
   return getDbClient() as BetterSQLite3Database<typeof sqliteSchema>;
@@ -34,6 +36,7 @@ afterAll(() => {
 });
 
 beforeEach(async () => {
+  await dbc().delete(schema.vpatSnapshots);
   await dbc().delete(schema.vpatCriterionRows);
   await dbc().delete(schema.vpats);
   await dbc().delete(schema.projects);
@@ -341,6 +344,29 @@ describe('getVpatsWithProgress', () => {
     });
     const results = await getVpatsWithProgress();
     expect(results[0]!.resolved).toBe(0);
+  });
+});
+
+describe('publishVpat snapshot creation', () => {
+  it('creates a snapshot when publishing', async () => {
+    const vpat = await createVpat({
+      title: 'Snap Test',
+      project_id: projectId,
+      standard_edition: 'WCAG',
+      wcag_version: '2.1',
+      wcag_level: 'AA',
+      product_scope: ['web'],
+    });
+    // Mark all rows as resolved
+    dbc()
+      .update(schema.vpatCriterionRows)
+      .set({ conformance: 'supports' })
+      .where(eq(schema.vpatCriterionRows.vpat_id, vpat.id))
+      .run();
+    await publishVpat(vpat.id);
+    const snapshots = await listVpatSnapshots(vpat.id);
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].version_number).toBe(2);
   });
 });
 

--- a/src/lib/db/__tests__/vpats.test.ts
+++ b/src/lib/db/__tests__/vpats.test.ts
@@ -366,7 +366,7 @@ describe('publishVpat snapshot creation', () => {
     await publishVpat(vpat.id);
     const snapshots = await listVpatSnapshots(vpat.id);
     expect(snapshots).toHaveLength(1);
-    expect(snapshots[0].version_number).toBe(2);
+    expect(snapshots[0]!.version_number).toBe(2);
   });
 });
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -120,6 +120,16 @@ export const vpatCriterionRows = sqliteTable('vpat_criterion_rows', {
   updated_at: text('updated_at').notNull(),
 });
 
+export const vpatSnapshots = sqliteTable('vpat_snapshots', {
+  id: text('id').primaryKey(),
+  vpat_id: text('vpat_id').notNull(),
+  version_number: integer('version_number').notNull(),
+  published_at: text('published_at').notNull(),
+  snapshot: text('snapshot').notNull(),
+});
+
+export type VpatSnapshotRow = typeof vpatSnapshots.$inferSelect;
+
 export const settings = sqliteTable('settings', {
   key: text('key').primaryKey(),
   value: text('value'),

--- a/src/lib/db/vpat-snapshots.ts
+++ b/src/lib/db/vpat-snapshots.ts
@@ -84,7 +84,7 @@ export async function getVpatSnapshot(
     .where(and(eq(vpatSnapshots.vpat_id, vpatId), eq(vpatSnapshots.version_number, versionNumber)))
     .all();
   if (rows.length === 0) return null;
-  const row = rows[0];
+  const row = rows[0]!;
   return {
     id: row.id,
     vpat_id: row.vpat_id,

--- a/src/lib/db/vpat-snapshots.ts
+++ b/src/lib/db/vpat-snapshots.ts
@@ -1,0 +1,95 @@
+import { eq, and, desc } from 'drizzle-orm';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { getDbClient } from './client';
+import { vpatSnapshots } from './schema';
+import type * as sqliteSchema from './schema';
+
+function db(): BetterSQLite3Database<typeof sqliteSchema> {
+  return getDbClient() as BetterSQLite3Database<typeof sqliteSchema>;
+}
+
+export interface SnapshotCriterionRow {
+  criterion_code: string;
+  criterion_name: string;
+  criterion_description: string;
+  criterion_level: string | null;
+  criterion_section: string;
+  conformance: string;
+  remarks: string | null;
+}
+
+export interface VpatSnapshotData {
+  title: string;
+  description: string | null;
+  standard_edition: string;
+  wcag_version: string;
+  wcag_level: string;
+  product_scope: string[];
+  criterion_rows: SnapshotCriterionRow[];
+}
+
+export interface VpatSnapshotSummary {
+  id: string;
+  vpat_id: string;
+  version_number: number;
+  published_at: string;
+}
+
+export interface VpatSnapshotFull extends VpatSnapshotSummary {
+  data: VpatSnapshotData;
+}
+
+export async function createVpatSnapshot(
+  vpatId: string,
+  versionNumber: number,
+  publishedAt: string,
+  data: VpatSnapshotData
+): Promise<VpatSnapshotSummary> {
+  const id = crypto.randomUUID();
+  db()
+    .insert(vpatSnapshots)
+    .values({
+      id,
+      vpat_id: vpatId,
+      version_number: versionNumber,
+      published_at: publishedAt,
+      snapshot: JSON.stringify(data),
+    })
+    .run();
+  return { id, vpat_id: vpatId, version_number: versionNumber, published_at: publishedAt };
+}
+
+export async function listVpatSnapshots(vpatId: string): Promise<VpatSnapshotSummary[]> {
+  const rows = db()
+    .select({
+      id: vpatSnapshots.id,
+      vpat_id: vpatSnapshots.vpat_id,
+      version_number: vpatSnapshots.version_number,
+      published_at: vpatSnapshots.published_at,
+    })
+    .from(vpatSnapshots)
+    .where(eq(vpatSnapshots.vpat_id, vpatId))
+    .orderBy(desc(vpatSnapshots.version_number))
+    .all();
+  return rows;
+}
+
+export async function getVpatSnapshot(
+  vpatId: string,
+  versionNumber: number
+): Promise<VpatSnapshotFull | null> {
+  const rows = db()
+    .select()
+    .from(vpatSnapshots)
+    .where(and(eq(vpatSnapshots.vpat_id, vpatId), eq(vpatSnapshots.version_number, versionNumber)))
+    .all();
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  return {
+    id: row.id,
+    vpat_id: row.vpat_id,
+    version_number: row.version_number,
+    published_at: row.published_at,
+    data: JSON.parse(row.snapshot) as VpatSnapshotData,
+  };
+}

--- a/src/lib/db/vpats.ts
+++ b/src/lib/db/vpats.ts
@@ -4,7 +4,9 @@ import { getDbClient } from './client';
 import { vpats, projects, vpatCriterionRows } from './schema';
 import type * as sqliteSchema from './schema';
 import { getCriteriaForEdition } from './criteria';
-import { createCriterionRows, countUnresolvedRows } from './vpat-criterion-rows';
+import { createCriterionRows, countUnresolvedRows, getCriterionRows } from './vpat-criterion-rows';
+import { createVpatSnapshot } from './vpat-snapshots';
+import type { VpatSnapshotData } from './vpat-snapshots';
 import type { CreateVpatParams, UpdateVpatInput } from '../validators/vpats';
 
 // Cast helper: the union type BetterSQLite3Database | PostgresJsDatabase does not
@@ -295,15 +297,37 @@ export async function publishVpat(id: string): Promise<Vpat> {
   if (unresolved > 0) {
     throw new UnresolvedRowsError(unresolved);
   }
+  // Capture criterion rows before status update (rows don't change during publish)
+  const criterionRows = await getCriterionRows(id);
+  const publishedAt = new Date().toISOString();
   db()
     .update(vpats)
     .set({
       status: 'published',
-      published_at: new Date().toISOString(),
+      published_at: publishedAt,
       version_number: sql`${vpats.version_number} + 1`,
-      updated_at: new Date().toISOString(),
+      updated_at: publishedAt,
     })
     .where(eq(vpats.id, id))
     .run();
-  return (await getVpat(id))!;
+  const published = (await getVpat(id))!;
+  const snapshotData: VpatSnapshotData = {
+    title: published.title,
+    description: published.description,
+    standard_edition: published.standard_edition,
+    wcag_version: published.wcag_version,
+    wcag_level: published.wcag_level,
+    product_scope: published.product_scope,
+    criterion_rows: criterionRows.map((r) => ({
+      criterion_code: r.criterion_code,
+      criterion_name: r.criterion_name,
+      criterion_description: r.criterion_description,
+      criterion_level: r.criterion_level,
+      criterion_section: r.criterion_section,
+      conformance: r.conformance,
+      remarks: r.remarks,
+    })),
+  };
+  await createVpatSnapshot(published.id, published.version_number, publishedAt, snapshotData);
+  return published;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['__tests__/setup.ts'],
-    exclude: ['node_modules/**', '.next/**', 'e2e/**'],
+    exclude: ['node_modules/**', '.next/**', 'e2e/**', '.worktrees/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
### Description

This pull request introduces features to support snapshot history for VPATs. Key changes include:

- Added a read-only VPAT version detail page.
- Implemented a `Version History` tab within the VPAT detail page.
- Created a `vpat_snapshots` database schema, migration, and module for managing snapshots.
- Introduced snapshot creation upon VPAT publishing.
- Exposed new API routes:
  - `GET /api/vpats/[id]/versions` to fetch version history.
  - `GET /api/vpats/[id]/versions/[version]` to fetch specific version details.
- Added route to export snapshots.

### Checklist

- [ ] Unit tests have been added or updated where applicable.
- [ ] Documentation has been updated to reflect these changes.
