### PR TITLE
feat: Issues pages style and layout alignment

### DIFF
--- a/src/app/(app)/issues/new/__tests__/new-issue-global-client.test.tsx
+++ b/src/app/(app)/issues/new/__tests__/new-issue-global-client.test.tsx
@@ -22,19 +22,21 @@ vi.mock('@/components/issues/issue-form', () => ({
     assessmentOptions,
     onAssessmentChange,
     loading,
+    externalButtons,
   }: {
     projectId: string;
     onSubmit: (data: Record<string, unknown>) => void;
     assessmentOptions?: Array<{ id: string; name: string; projectId: string; projectName: string }>;
     onAssessmentChange?: (assessmentId: string, projectId: string) => void;
     loading?: boolean;
+    externalButtons?: string;
   }) => (
-    <div>
+    <form id={externalButtons} onSubmit={(e) => { e.preventDefault(); onSubmit({ title: 'Test Issue', severity: 'high' }); }}>
       <span data-testid="assessment-options-count">{assessmentOptions?.length ?? 0}</span>
       <span data-testid="issue-form-loading">{loading ? 'loading' : 'idle'}</span>
       <button onClick={() => onAssessmentChange?.('a1', 'p1')}>Select Assessment</button>
-      <button onClick={() => onSubmit({ title: 'Test Issue', severity: 'high' })}>Submit</button>
-    </div>
+      <button type="submit">Submit</button>
+    </form>
   ),
 }));
 
@@ -127,5 +129,18 @@ describe('NewIssueGlobalClient', () => {
 
     expect(mockToastError).toHaveBeenCalledWith('Failed to create issue');
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('renders a Cancel link pointing to /issues', () => {
+    render(<NewIssueGlobalClient assessments={assessments} />);
+    const cancelLink = screen.getByRole('link', { name: /cancel/i });
+    expect(cancelLink).toHaveAttribute('href', '/issues');
+  });
+
+  it('renders a Save Issue submit button with the form attribute', () => {
+    render(<NewIssueGlobalClient assessments={assessments} />);
+    const btn = screen.getByRole('button', { name: /save issue/i });
+    expect(btn).toHaveAttribute('type', 'submit');
+    expect(btn).toHaveAttribute('form', 'new-issue-form');
   });
 });

--- a/src/app/(app)/issues/new/new-issue-global-client.tsx
+++ b/src/app/(app)/issues/new/new-issue-global-client.tsx
@@ -2,9 +2,14 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import Link from 'next/link';
 import { IssueForm } from '@/components/issues/issue-form';
+import { Button } from '@/components/ui/button';
 import type { CreateIssueInput, UpdateIssueInput } from '@/lib/validators/issues';
 import type { AssessmentWithProject } from '@/lib/db/assessments';
+
+const FORM_ID = 'new-issue-form';
 
 interface NewIssueGlobalClientProps {
   assessments: AssessmentWithProject[];
@@ -58,7 +63,7 @@ export function NewIssueGlobalClient({ assessments }: NewIssueGlobalClientProps)
   };
 
   return (
-    <>
+    <div className="space-y-6">
       <h1 className="text-2xl font-bold">New Issue</h1>
       <IssueForm
         projectId={selectedProjectId ?? ''}
@@ -66,8 +71,20 @@ export function NewIssueGlobalClient({ assessments }: NewIssueGlobalClientProps)
         onAssessmentChange={handleAssessmentChange}
         onSubmit={handleSubmit}
         loading={loading}
-        cancelHref="/issues"
+        externalButtons={FORM_ID}
       />
-    </>
+      <div className="flex justify-between">
+        <Button variant="cancel" asChild>
+          <Link href="/issues">
+            <X className="h-4 w-4" />
+            Cancel
+          </Link>
+        </Button>
+        <Button type="submit" form={FORM_ID} disabled={loading}>
+          <Save className="h-4 w-4" />
+          Save Issue
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/__tests__/page.test.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/__tests__/page.test.tsx
@@ -50,8 +50,8 @@ vi.mock('next/navigation', () => ({
   },
 }));
 
-vi.mock('@/components/issues/delete-issue-button', () => ({
-  DeleteIssueButton: () => <button>Delete</button>,
+vi.mock('@/components/issues/issue-settings-menu', () => ({
+  IssueSettingsMenu: () => <button aria-label="Issue settings">Settings</button>,
 }));
 
 vi.mock('@/components/issues/media-gallery', () => ({
@@ -97,4 +97,10 @@ test('URL link does not appear in the header area', async () => {
   const heading = screen.getByRole('heading', { name: 'Missing alt text' });
   const headerWrapper = heading.closest('[class*="space-y"]');
   expect(headerWrapper).not.toHaveTextContent('https://example.com/page');
+});
+
+test('renders IssueSettingsMenu in the hero card header', async () => {
+  const page = await IssueDetailPage(defaultProps);
+  render(page);
+  expect(screen.getByRole('button', { name: /issue settings/i })).toBeInTheDocument();
 });

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/edit/__tests__/page.test.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/edit/__tests__/page.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const { mockPush, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ projectId: 'p1', assessmentId: 'a1', issueId: 'i1' }),
+}));
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}));
+vi.mock('@/components/issues/issue-form', () => ({
+  IssueForm: ({
+    onSubmit,
+    externalButtons,
+    loading,
+  }: {
+    onSubmit: (data: Record<string, unknown>) => void;
+    externalButtons?: string;
+    loading?: boolean;
+  }) => (
+    <form id={externalButtons} onSubmit={(e) => { e.preventDefault(); onSubmit({ title: 'Test' }); }}>
+      <span data-testid="form-loading">{loading ? 'loading' : 'idle'}</span>
+    </form>
+  ),
+}));
+vi.mock('@/components/issues/delete-issue-button', () => ({
+  DeleteIssueButton: ({ issueId }: { issueId: string }) => (
+    <button data-testid={`delete-${issueId}`}>Delete</button>
+  ),
+}));
+
+global.fetch = vi.fn();
+
+import EditIssuePage from '../page';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+    if (url.includes('/issues/i1')) {
+      return Promise.resolve({
+        json: async () => ({ success: true, data: { id: 'i1', title: 'Missing alt text', severity: 'high', status: 'open', wcag_codes: [], section_508_codes: [], eu_codes: [], tags: [], evidence_media: [] } }),
+      });
+    }
+    if (url.includes('/assessments/a1') && !url.includes('/issues/')) {
+      return Promise.resolve({
+        json: async () => ({ success: true, data: { name: 'Q1 Audit' } }),
+      });
+    }
+    return Promise.resolve({
+      json: async () => ({ success: true, data: { name: 'My Project' } }),
+    });
+  });
+});
+
+describe('EditIssuePage', () => {
+  it('renders the Edit Issue heading', async () => {
+    render(<EditIssuePage />);
+    expect(await screen.findByRole('heading', { name: /edit issue/i })).toBeInTheDocument();
+  });
+
+  it('renders a Cancel button linking back to the issue detail page', async () => {
+    render(<EditIssuePage />);
+    await screen.findByRole('heading', { name: /edit issue/i });
+    const cancelLink = screen.getByRole('link', { name: /cancel/i });
+    expect(cancelLink).toHaveAttribute('href', '/projects/p1/assessments/a1/issues/i1');
+  });
+
+  it('renders a Save Issue submit button with form attribute', async () => {
+    render(<EditIssuePage />);
+    await screen.findByRole('heading', { name: /edit issue/i });
+    const saveBtn = screen.getByRole('button', { name: /save issue/i });
+    expect(saveBtn).toHaveAttribute('type', 'submit');
+    expect(saveBtn).toHaveAttribute('form', 'edit-issue-form');
+  });
+
+  it('renders the DeleteIssueButton in the external button bar', async () => {
+    render(<EditIssuePage />);
+    await screen.findByRole('heading', { name: /edit issue/i });
+    expect(screen.getByTestId('delete-i1')).toBeInTheDocument();
+  });
+
+  it('Save Issue button has an icon', async () => {
+    render(<EditIssuePage />);
+    await screen.findByRole('heading', { name: /edit issue/i });
+    const btn = screen.getByRole('button', { name: /save issue/i });
+    expect(btn.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('Cancel button has an icon', async () => {
+    render(<EditIssuePage />);
+    await screen.findByRole('heading', { name: /edit issue/i });
+    const link = screen.getByRole('link', { name: /cancel/i });
+    expect(link.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/edit/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/edit/page.tsx
@@ -2,10 +2,16 @@
 import { useParams, useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import Link from 'next/link';
 import { IssueForm } from '@/components/issues/issue-form';
+import { DeleteIssueButton } from '@/components/issues/delete-issue-button';
 import { Breadcrumbs } from '@/components/ui/breadcrumbs';
+import { Button } from '@/components/ui/button';
 import type { Issue } from '@/lib/db/issues';
 import type { UpdateIssueInput } from '@/lib/validators/issues';
+
+const FORM_ID = 'edit-issue-form';
 
 export default function EditIssuePage() {
   const params = useParams();
@@ -80,6 +86,8 @@ export default function EditIssuePage() {
     return <div className="p-6 text-destructive">Issue not found.</div>;
   }
 
+  const cancelHref = `/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`;
+
   return (
     <div className="space-y-6">
       <Breadcrumbs
@@ -98,7 +106,7 @@ export default function EditIssuePage() {
           { label: 'Issues' },
           {
             label: issue.title,
-            href: `/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`,
+            href: cancelHref,
           },
           { label: 'Edit' },
         ]}
@@ -109,8 +117,28 @@ export default function EditIssuePage() {
         issue={issue}
         onSubmit={handleSubmit}
         loading={loading}
-        cancelHref={`/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`}
+        externalButtons={FORM_ID}
       />
+      <div className="flex justify-between">
+        <Button variant="cancel" asChild>
+          <Link href={cancelHref}>
+            <X className="h-4 w-4" />
+            Cancel
+          </Link>
+        </Button>
+        <div className="flex gap-2">
+          <DeleteIssueButton
+            projectId={projectId}
+            assessmentId={assessmentId}
+            issueId={issueId}
+            issueTitle={issue.title}
+          />
+          <Button type="submit" form={FORM_ID} disabled={loading}>
+            <Save className="h-4 w-4" />
+            Save Issue
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/[issueId]/page.tsx
@@ -1,8 +1,6 @@
-import Link from 'next/link';
-import { Pencil } from 'lucide-react';
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { Breadcrumbs } from '@/components/ui/breadcrumbs';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getProject } from '@/lib/db/projects';
@@ -10,7 +8,7 @@ import { getAssessment } from '@/lib/db/assessments';
 import { getIssue } from '@/lib/db/issues';
 import { SeverityBadge } from '@/components/issues/severity-badge';
 import { StatusBadge } from '@/components/issues/status-badge';
-import { DeleteIssueButton } from '@/components/issues/delete-issue-button';
+import { IssueSettingsMenu } from '@/components/issues/issue-settings-menu';
 import { MediaGallery } from '@/components/issues/media-gallery';
 
 export const dynamic = 'force-dynamic';
@@ -55,31 +53,23 @@ export default async function IssueDetailPage({
         ]}
       />
 
-      {/* Header */}
-      <div className="flex items-start justify-between">
-        <div className="space-y-2">
-          <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-2xl font-bold">{issue.title}</h1>
-            <SeverityBadge severity={issue.severity} />
-            <StatusBadge status={issue.status} />
-          </div>
-          <Link
-            href={`/projects/${projectId}/assessments/${assessmentId}`}
-            className="text-sm text-primary hover:underline"
-          >
-            {assessment.name}
-          </Link>
-        </div>
-        <div className="flex gap-2 shrink-0">
-          <Button variant="outline" asChild>
+      {/* Hero card */}
+      <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 px-6 shadow-sm">
+        <div className="flex items-start justify-between">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 flex-wrap">
+              <h1 className="text-2xl font-bold">{issue.title}</h1>
+              <SeverityBadge severity={issue.severity} />
+              <StatusBadge status={issue.status} />
+            </div>
             <Link
-              href={`/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}/edit`}
+              href={`/projects/${projectId}/assessments/${assessmentId}`}
+              className="text-sm text-primary hover:underline"
             >
-              <Pencil className="mr-2 h-4 w-4" />
-              Edit
+              {assessment.name}
             </Link>
-          </Button>
-          <DeleteIssueButton
+          </div>
+          <IssueSettingsMenu
             projectId={projectId}
             assessmentId={assessmentId}
             issueId={issueId}

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/new/__tests__/new-issue-client.test.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/new/__tests__/new-issue-client.test.tsx
@@ -20,15 +20,17 @@ vi.mock('@/components/issues/issue-form', () => ({
   IssueForm: ({
     onSubmit,
     loading,
+    externalButtons,
   }: {
     projectId: string;
     onSubmit: (data: Record<string, unknown>) => void;
     loading?: boolean;
+    externalButtons?: string;
   }) => (
-    <div>
+    <form id={externalButtons} onSubmit={(e) => { e.preventDefault(); onSubmit({ title: 'Test Issue', severity: 'high' }); }}>
       <span data-testid="issue-form-loading">{loading ? 'loading' : 'idle'}</span>
-      <button onClick={() => onSubmit({ title: 'Test Issue', severity: 'high' })}>Submit</button>
-    </div>
+      <button type="submit">Submit</button>
+    </form>
   ),
 }));
 
@@ -57,7 +59,7 @@ describe('NewIssueClient', () => {
     });
 
     render(<NewIssueClient projectId="p1" assessmentId="a1" />);
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
     expect(global.fetch).toHaveBeenCalledWith(
       '/api/projects/p1/assessments/a1/issues',
@@ -78,7 +80,7 @@ describe('NewIssueClient', () => {
     });
 
     render(<NewIssueClient projectId="p1" assessmentId="a1" />);
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
     expect(mockToastError).toHaveBeenCalledWith('Failed to create issue');
     expect(mockToastSuccess).not.toHaveBeenCalled();
@@ -89,10 +91,35 @@ describe('NewIssueClient', () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Network error'));
 
     render(<NewIssueClient projectId="p1" assessmentId="a1" />);
-    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
 
     expect(mockToastError).toHaveBeenCalledWith('Failed to create issue');
     expect(mockToastSuccess).not.toHaveBeenCalled();
     expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('renders a Cancel link pointing to the assessment page', () => {
+    render(<NewIssueClient projectId="p1" assessmentId="a1" />);
+    const cancelLink = screen.getByRole('link', { name: /cancel/i });
+    expect(cancelLink).toHaveAttribute('href', '/projects/p1/assessments/a1');
+  });
+
+  it('renders a Save Issue submit button with the form attribute', () => {
+    render(<NewIssueClient projectId="p1" assessmentId="a1" />);
+    const btn = screen.getByRole('button', { name: /save issue/i });
+    expect(btn).toHaveAttribute('type', 'submit');
+    expect(btn).toHaveAttribute('form', 'new-issue-form');
+  });
+
+  it('Save Issue button has an icon', () => {
+    render(<NewIssueClient projectId="p1" assessmentId="a1" />);
+    const btn = screen.getByRole('button', { name: /save issue/i });
+    expect(btn.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('Cancel link has an icon', () => {
+    render(<NewIssueClient projectId="p1" assessmentId="a1" />);
+    const link = screen.getByRole('link', { name: /cancel/i });
+    expect(link.querySelector('svg')).toBeInTheDocument();
   });
 });

--- a/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/new/new-issue-client.tsx
+++ b/src/app/(app)/projects/[projectId]/assessments/[assessmentId]/issues/new/new-issue-client.tsx
@@ -2,8 +2,13 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { Save, X } from 'lucide-react';
+import Link from 'next/link';
 import { IssueForm } from '@/components/issues/issue-form';
+import { Button } from '@/components/ui/button';
 import type { CreateIssueInput, UpdateIssueInput } from '@/lib/validators/issues';
+
+const FORM_ID = 'new-issue-form';
 
 interface NewIssueClientProps {
   projectId: string;
@@ -33,15 +38,29 @@ export function NewIssueClient({ projectId, assessmentId }: NewIssueClientProps)
     }
   };
 
+  const cancelHref = `/projects/${projectId}/assessments/${assessmentId}`;
+
   return (
-    <>
+    <div className="space-y-6">
       <h1 className="text-2xl font-bold">New Issue</h1>
       <IssueForm
         projectId={projectId}
         onSubmit={handleSubmit}
         loading={loading}
-        cancelHref={`/projects/${projectId}/assessments/${assessmentId}`}
+        externalButtons={FORM_ID}
       />
-    </>
+      <div className="flex justify-between">
+        <Button variant="cancel" asChild>
+          <Link href={cancelHref}>
+            <X className="h-4 w-4" />
+            Cancel
+          </Link>
+        </Button>
+        <Button type="submit" form={FORM_ID} disabled={loading}>
+          <Save className="h-4 w-4" />
+          Save Issue
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/components/issues/__tests__/delete-issue-button.test.tsx
+++ b/src/components/issues/__tests__/delete-issue-button.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+const { mockPush, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}));
+
+global.fetch = vi.fn();
+
+import { DeleteIssueButton } from '../delete-issue-button';
+
+const defaultProps = {
+  projectId: 'p1',
+  assessmentId: 'a1',
+  issueId: 'i1',
+  issueTitle: 'Missing alt text',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders a trigger button with Trash2 icon', () => {
+  render(<DeleteIssueButton {...defaultProps} />);
+  const btn = screen.getByRole('button', { name: /delete/i });
+  expect(btn.querySelector('svg')).toBeInTheDocument();
+});
+
+test('opens confirmation dialog when trigger is clicked', async () => {
+  render(<DeleteIssueButton {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+  expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+});
+
+test('AlertDialogCancel has an X icon', async () => {
+  render(<DeleteIssueButton {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const cancelBtn = await screen.findByRole('button', { name: /cancel/i });
+  expect(cancelBtn.querySelector('svg')).toBeInTheDocument();
+});
+
+test('AlertDialogAction has a Trash2 icon', async () => {
+  render(<DeleteIssueButton {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+  const deleteBtn = await screen.findByRole('button', { name: /delete issue/i });
+  expect(deleteBtn.querySelector('svg')).toBeInTheDocument();
+});
+
+test('confirming delete calls API and navigates to assessment', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: true }),
+  });
+  render(<DeleteIssueButton {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+  await userEvent.click(await screen.findByRole('button', { name: /delete issue/i }));
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/projects/p1/assessments/a1/issues/i1',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+  expect(mockPush).toHaveBeenCalledWith('/projects/p1/assessments/a1');
+  expect(mockToastSuccess).toHaveBeenCalledWith('Issue deleted');
+});

--- a/src/components/issues/__tests__/issue-form.test.tsx
+++ b/src/components/issues/__tests__/issue-form.test.tsx
@@ -25,6 +25,42 @@ const assessmentOptions: AssessmentOption[] = [
   { id: 'a2', name: 'Q2 Audit', projectId: 'p2', projectName: 'Beta App' },
 ];
 
+describe('IssueForm externalButtons prop', () => {
+  it('renders internal Save and Cancel buttons when externalButtons is not set', () => {
+    render(<IssueForm projectId="p1" onSubmit={vi.fn()} cancelHref="/back" />);
+    expect(screen.getByRole('button', { name: /save issue/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('hides internal buttons when externalButtons prop is provided', () => {
+    render(
+      <IssueForm projectId="p1" onSubmit={vi.fn()} cancelHref="/back" externalButtons="my-form" />
+    );
+    expect(screen.queryByRole('button', { name: /save issue/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /cancel/i })).not.toBeInTheDocument();
+  });
+
+  it('sets the form id when externalButtons prop is provided', () => {
+    const { container } = render(
+      <IssueForm projectId="p1" onSubmit={vi.fn()} externalButtons="my-form" />
+    );
+    const form = container.querySelector('form');
+    expect(form).toHaveAttribute('id', 'my-form');
+  });
+
+  it('Save Issue button has an icon', () => {
+    render(<IssueForm projectId="p1" onSubmit={vi.fn()} />);
+    const btn = screen.getByRole('button', { name: /save issue/i });
+    expect(btn.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('Cancel button has an icon', () => {
+    render(<IssueForm projectId="p1" onSubmit={vi.fn()} cancelHref="/back" />);
+    const btn = screen.getByRole('link', { name: /cancel/i });
+    expect(btn.querySelector('svg')).toBeInTheDocument();
+  });
+});
+
 describe('IssueForm assessment selector', () => {
   it('does not render an assessment selector when assessmentOptions is not provided', () => {
     render(<IssueForm projectId="p1" onSubmit={vi.fn()} />);

--- a/src/components/issues/__tests__/issue-settings-menu.test.tsx
+++ b/src/components/issues/__tests__/issue-settings-menu.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+const { mockPush, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+vi.mock('sonner', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
+}));
+
+global.fetch = vi.fn();
+
+import { IssueSettingsMenu } from '../issue-settings-menu';
+
+const defaultProps = {
+  projectId: 'p1',
+  assessmentId: 'a1',
+  issueId: 'i1',
+  issueTitle: 'Missing alt text',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('renders a settings trigger button', () => {
+  render(<IssueSettingsMenu {...defaultProps} />);
+  expect(screen.getByRole('button', { name: /issue settings/i })).toBeInTheDocument();
+});
+
+test('dropdown contains Edit Issue link pointing to edit page', async () => {
+  render(<IssueSettingsMenu {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /issue settings/i }));
+  const item = await screen.findByRole('menuitem', { name: /edit issue/i });
+  expect(item).toHaveAttribute('href', '/projects/p1/assessments/a1/issues/i1/edit');
+});
+
+test('dropdown contains Delete Issue item', async () => {
+  render(<IssueSettingsMenu {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /issue settings/i }));
+  expect(await screen.findByRole('menuitem', { name: /delete issue/i })).toBeInTheDocument();
+});
+
+test('clicking Delete Issue opens a confirmation dialog', async () => {
+  render(<IssueSettingsMenu {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /issue settings/i }));
+  await userEvent.click(await screen.findByRole('menuitem', { name: /delete issue/i }));
+  expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+  expect(screen.getByText(/missing alt text/i)).toBeInTheDocument();
+});
+
+test('confirming delete calls the issues API and navigates to assessment', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: true }),
+  });
+  render(<IssueSettingsMenu {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /issue settings/i }));
+  await userEvent.click(await screen.findByRole('menuitem', { name: /delete issue/i }));
+  await userEvent.click(await screen.findByRole('button', { name: /delete issue/i }));
+  await waitFor(() => {
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/projects/p1/assessments/a1/issues/i1',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+  expect(mockPush).toHaveBeenCalledWith('/projects/p1/assessments/a1');
+  expect(mockToastSuccess).toHaveBeenCalledWith('Issue deleted');
+});
+
+test('failed delete shows error toast', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    json: async () => ({ success: false, error: 'DB error' }),
+  });
+  render(<IssueSettingsMenu {...defaultProps} />);
+  await userEvent.click(screen.getByRole('button', { name: /issue settings/i }));
+  await userEvent.click(await screen.findByRole('menuitem', { name: /delete issue/i }));
+  await userEvent.click(await screen.findByRole('button', { name: /delete issue/i }));
+  await waitFor(() => {
+    expect(mockToastError).toHaveBeenCalledWith('Failed to delete issue');
+  });
+  expect(mockPush).not.toHaveBeenCalled();
+});

--- a/src/components/issues/__tests__/issues-list-view.test.tsx
+++ b/src/components/issues/__tests__/issues-list-view.test.tsx
@@ -147,6 +147,34 @@ describe('IssuesListView New Issue button', () => {
   });
 });
 
+describe('IssuesListView layout and style', () => {
+  beforeEach(() => { mockSeverity = null; });
+
+  it('renders a section with aria-labelledby pointing to the Issues heading', () => {
+    const { container } = render(<IssuesListView issues={[]} />);
+    const section = container.querySelector('section[aria-labelledby]');
+    expect(section).toBeInTheDocument();
+    const headingId = section!.getAttribute('aria-labelledby');
+    expect(document.getElementById(headingId!)).toHaveTextContent('Issues');
+  });
+
+  it('New Issue button does not have the outline variant class', () => {
+    render(<IssuesListView issues={[]} />);
+    const link = screen.getByRole('link', { name: /new issue/i });
+    expect(link.className).not.toContain('border-input');
+  });
+
+  it('shows an empty state message when no issues match the filter', () => {
+    render(<IssuesListView issues={[]} />);
+    expect(screen.getByText(/no issues found/i)).toBeInTheDocument();
+  });
+
+  it('does not show empty state when issues are present', () => {
+    render(<IssuesListView issues={[makeIssue('i1', 'high')]} />);
+    expect(screen.queryByText(/no issues found/i)).not.toBeInTheDocument();
+  });
+});
+
 describe('IssuesListView severity filter', () => {
   beforeEach(() => {
     mockSeverity = null;

--- a/src/components/issues/delete-issue-button.tsx
+++ b/src/components/issues/delete-issue-button.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { Trash2 } from 'lucide-react';
+import { Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   AlertDialog,
@@ -52,7 +52,7 @@ export function DeleteIssueButton({
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="destructive" size="sm" disabled={loading}>
+        <Button variant="destructive" disabled={loading}>
           <Trash2 className="mr-2 h-4 w-4" />
           Delete
         </Button>
@@ -66,11 +66,15 @@ export function DeleteIssueButton({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>
+            <X className="h-4 w-4" />
+            Cancel
+          </AlertDialogCancel>
           <AlertDialogAction
             onClick={handleDelete}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
+            <Trash2 className="h-4 w-4" />
             Delete Issue
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/components/issues/issue-form.tsx
+++ b/src/components/issues/issue-form.tsx
@@ -2,7 +2,7 @@
 import { useState, useMemo } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Save, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -40,6 +40,7 @@ interface IssueFormProps {
   onSubmit: (data: CreateIssueInput | UpdateIssueInput) => void;
   loading?: boolean;
   cancelHref?: string;
+  externalButtons?: string;
 }
 
 export function IssueForm({
@@ -50,6 +51,7 @@ export function IssueForm({
   onSubmit,
   loading,
   cancelHref,
+  externalButtons,
 }: IssueFormProps) {
   // AI assistance state — not part of the submitted form
   const [aiDescription, setAiDescription] = useState('');
@@ -156,7 +158,7 @@ export function IssueForm({
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} id={externalButtons}>
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Left column: all form fields */}
         <Card className="lg:col-span-2">
@@ -479,16 +481,22 @@ export function IssueForm({
               />
             </div>
 
-            <div className="flex gap-2">
-              <Button type="submit" size="sm" disabled={loading}>
-                {loading ? 'Saving…' : 'Save Issue'}
-              </Button>
-              {cancelHref && (
-                <Button asChild variant="cancel" size="sm">
-                  <Link href={cancelHref}>Cancel</Link>
+            {!externalButtons && (
+              <div className="flex gap-2">
+                <Button type="submit" disabled={loading}>
+                  <Save className="h-4 w-4" />
+                  {loading ? 'Saving…' : 'Save Issue'}
                 </Button>
-              )}
-            </div>
+                {cancelHref && (
+                  <Button asChild variant="cancel">
+                    <Link href={cancelHref}>
+                      <X className="h-4 w-4" />
+                      Cancel
+                    </Link>
+                  </Button>
+                )}
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/src/components/issues/issue-settings-menu.tsx
+++ b/src/components/issues/issue-settings-menu.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Link from 'next/link';
+import { Settings, Pencil, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface IssueSettingsMenuProps {
+  projectId: string;
+  assessmentId: string;
+  issueId: string;
+  issueTitle: string;
+}
+
+export function IssueSettingsMenu({
+  projectId,
+  assessmentId,
+  issueId,
+  issueTitle,
+}: IssueSettingsMenuProps) {
+  const router = useRouter();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const baseUrl = `/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`;
+
+  async function handleDelete() {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `/api/projects/${projectId}/assessments/${assessmentId}/issues/${issueId}`,
+        { method: 'DELETE' }
+      );
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error);
+      toast.success('Issue deleted');
+      router.push(`/projects/${projectId}/assessments/${assessmentId}`);
+    } catch {
+      toast.error('Failed to delete issue');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label="Issue settings">
+            <Settings className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild>
+            <Link href={`${baseUrl}/edit`}>
+              <Pencil className="mr-2 h-4 w-4" />
+              Edit Issue
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setDeleteOpen(true)}>
+            <Trash2 className="mr-2 h-4 w-4" />
+            Delete Issue
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {issueTitle}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the issue and all associated data. This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              <X className="h-4 w-4" />
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} disabled={loading}>
+              <Trash2 className="h-4 w-4" />
+              Delete Issue
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/issues/issues-list-view.tsx
+++ b/src/components/issues/issues-list-view.tsx
@@ -41,11 +41,11 @@ export function IssuesListView({ issues }: IssuesListViewProps) {
     : afterSeverity;
 
   return (
-    <main className="p-6 space-y-6">
+    <section aria-labelledby="issues-heading" className="p-6 space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-lg font-semibold">Issues</h1>
+        <h1 id="issues-heading" className="text-lg font-semibold">Issues</h1>
         <div className="flex items-center gap-2">
-          <Button asChild variant="outline" size="sm">
+          <Button asChild variant="success" size="sm">
             <Link href="/issues/new">
               <Plus className="mr-2 h-4 w-4" />
               New Issue
@@ -99,7 +99,11 @@ export function IssuesListView({ issues }: IssuesListViewProps) {
         </div>
       </div>
 
-      {view === 'grid' ? (
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+          No issues found.
+        </div>
+      ) : view === 'grid' ? (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {filtered.map((i) => (
             <IssueCard key={i.id} issue={i} />
@@ -112,6 +116,6 @@ export function IssuesListView({ issues }: IssuesListViewProps) {
           </CardContent>
         </Card>
       )}
-    </main>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

- **IssueForm**: Added `externalButtons` prop — when set, the form renders with `id={externalButtons}` and hides its internal Save/Cancel buttons; added Save/X icons to internal buttons
- **IssuesListView**: Changed `<main>` to `<section aria-labelledby>`, New Issue button to `variant="success"`, added empty state with dashed border
- **IssueSettingsMenu** (new): Settings dropdown with Edit Issue link and inline Delete confirmation dialog, matching `AssessmentSettingsMenu` pattern
- **Issue detail page**: Wrapped header in hero card div, replaced Edit + Delete buttons with `IssueSettingsMenu`
- **DeleteIssueButton**: Added X icon to Cancel, Trash2 icon to Action, removed `size="sm"` from trigger
- **Edit Issue page**: Added `FORM_ID`, `externalButtons` prop, external Cancel/Delete/Save button bar
- **New Issue pages**: External Cancel/Save button bar on both project-scoped and global variants

## Test plan

- [ ] All 1548 existing tests pass (`npx vitest run`)
- [ ] New Issue page (project-scoped and global) — Save/Cancel buttons appear below the form
- [ ] Edit Issue page — Cancel/Delete/Save bar appears below the form; Delete opens confirmation dialog
- [ ] Issue detail page — hero card with settings gear icon; Edit navigates to edit page; Delete opens confirmation and removes issue
- [ ] Issues list — New Issue button uses success (green) style; empty state shows when no issues match filter